### PR TITLE
feat: 修改几个订单的图标,分割线等

### DIFF
--- a/components/sale/add/Parts.vue
+++ b/components/sale/add/Parts.vue
@@ -27,7 +27,7 @@ const hold = ref(0)
             showModal = true
           }
           ">
-          <icon name="i-icon:search" color="#FFF" :size="12" />
+          <icon name="i-icon:search" color="#FFF" :size="16" />
           <div class="ml-2">
             搜索
           </div>

--- a/components/sale/add/Settlement.vue
+++ b/components/sale/add/Settlement.vue
@@ -209,7 +209,7 @@ const unPayMoney = computed(() => {
             </div>
           </template>
         </div>
-        <div class="border-y-[#E6E6E8] border border-y-solid py-[12px] mb-[12px]">
+        <div class="border-t-[#E6E6E8] border border-t-solid py-[12px] mb-[12px]">
           <div class="text-[16px] color-[#3971F3] line-height-[24px] text-right font-semibold">
             剩余未支付:{{ unPayMoney }}
           </div>

--- a/components/sale/add/masterials/Button.vue
+++ b/components/sale/add/masterials/Button.vue
@@ -10,7 +10,7 @@ const emits = defineEmits<{
     <div class="grid-12 gap-[8px]">
       <div
         class="btn-left col-6 cursor-pointer" uno-sm="col-4 offset-2" @click="emits('searchQl')">
-        <icon name="i-icon:search" color="#fff" :size="12" />
+        <icon name="i-icon:search" color="#fff" :size="16" />
         <div class="ml-2">
           搜索
         </div>

--- a/components/sale/add/product/Button.vue
+++ b/components/sale/add/product/Button.vue
@@ -9,7 +9,7 @@ const emits = defineEmits<{
     <div class="btn grid-12 gap-[8px]">
       <div
         class="btn-left col-6 offset-3 cursor-pointer" uno-sm="col-4 offset-4" @click="emits('search')">
-        <icon name="i-icon:search" color="#fff" :size="12" />
+        <icon name="i-icon:search" color="#fff" :size="16" />
         <div class="ml-2">
           搜索
         </div>

--- a/components/sale/deposit/Product.vue
+++ b/components/sale/deposit/Product.vue
@@ -57,7 +57,7 @@ const handleAddProductPopup = ref(false)
         <div class="btn grid-12 gap-[8px]">
           <div
             class="btn-left col-6 cursor-pointer" uno-sm="col-4 offset-2" @click="showModal = true">
-            <icon name="i-icon:search" color="#fff" :size="12" />
+            <icon name="i-icon:search" color="#fff" :size="16" />
             <div class="ml-2">
               搜索
             </div>

--- a/components/sale/other/Balance.vue
+++ b/components/sale/other/Balance.vue
@@ -80,7 +80,7 @@ const totalMoney = () => {
             </div>
           </template>
         </div>
-        <div class="border-b-[#E6E6E8] border border-b-solid py-[12px] mb-[12px]">
+        <div class=" py-[12px] mb-[12px]">
           <div class="text-[16px] color-[#3971F3] line-height-[24px] text-right font-semibold">
             订单金额:{{ totalMoney() }}
           </div>

--- a/components/sale/service/add/select/Button.vue
+++ b/components/sale/service/add/select/Button.vue
@@ -11,7 +11,7 @@ const emits = defineEmits<{
       <div
         class="btn-left col-6  cursor-pointer" uno-sm="col-4 offset-2" @click="emits('searchQl')"
       >
-        <icon name="i-icon:search" color="#fff" :size="12" />
+        <icon name="i-icon:search" color="#fff" :size="16" />
         <div class="ml-2">
           搜索
         </div>

--- a/pages/sale/other/add.vue
+++ b/pages/sale/other/add.vue
@@ -119,7 +119,7 @@ const handleValidateButtonClick = (e: any) => {
 
 <template>
   <div :key="Key">
-    <div class="grid-12">
+    <div class="grid-12 pb-[16px]">
       <div class="flex flex-col w-auto gap-[16px] px-[16px] py-[16px] pb-[80px] col-12" uno-xs="col-12" uno-sm="col-8 offset-2" uno-md="col-6 offset-3">
         <n-form
           ref="formRef"

--- a/pages/sale/sales/add.vue
+++ b/pages/sale/sales/add.vue
@@ -377,7 +377,7 @@ const changeStore = () => {
 </script>
 
 <template>
-  <div :key="Key" class="grid-12">
+  <div :key="Key" class="grid-12 pb-[16px]">
     <div class="flex flex-col w-auto gap-[16px] px-[16px] py-[16px] pb-[80px] col-12" uno-xs="col-12" uno-sm="col-8 offset-2" uno-md="col-6 offset-3">
       <n-form
         ref="formRef"


### PR DESCRIPTION
新增销售单-搜索、扫码按钮icon调整为16px，备注距分割线上间距16px；内容距底部下间距16px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
  - 多处按钮和图标的尺寸优化，搜索和操作按钮中的图标由 12 调整为 16，提升视觉清晰度。
  - 优化部分容器的边框样式，调整未支付金额及订单金额展示区域的边框显示效果。
  - 页面主容器底部新增 16px 内边距，改善整体页面间距和布局。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->