### PR TITLE
feat: 移除订单页面的返回按钮

### DIFF
--- a/components/sale/sales/Details.vue
+++ b/components/sale/sales/Details.vue
@@ -35,6 +35,8 @@ const handleClick = () => {
               </div>
             </div>
           </div>
+        </template>
+        <template #footer>
           <div class="flex-end bg-[#F3F5FE] rounded-b-[24px] dark:bg-[rgba(243,245,254,0.1)]">
             <common-button-irregular text="查看详情" @click="handleClick" />
           </div>

--- a/components/sale/sales/Refund.vue
+++ b/components/sale/sales/Refund.vue
@@ -35,6 +35,8 @@ const handleClick = () => {
               </div>
             </div>
           </div>
+        </template>
+        <template #footer>
           <div class="flex-end bg-[#F3F5FE] rounded-b-[24px] dark:bg-[rgba(243,245,254,0.1)]">
             <common-button-irregular text="查看详情" @click="handleClick" />
           </div>

--- a/pages/sale/deposit/order.vue
+++ b/pages/sale/deposit/order.vue
@@ -9,7 +9,7 @@ const { getMemberWhere } = useMemberManage()
 const { filterList: memberFiler } = storeToRefs(useMemberManage())
 const { OrderDetail, filterList } = storeToRefs(useDepositOrder())
 const { getOrderDetail, getSaleWhere, returnGoodsDepositOrder } = useDepositOrder()
-const router = useRouter()
+
 const route = useRoute()
 if (route.query.id) {
   await getOrderDetail({ id: route.query.id as string })
@@ -32,16 +32,6 @@ const returnGoods = async (req: DepositReturnGoods) => {
   <div>
     <div class="p-[16px] pb-[80px]">
       <sale-deposit-details :member-filer="memberFiler" :product-filter="finishedFilterList" :where="filterList" :orders="OrderDetail" :return-goods="returnGoods" />
-    </div>
-    <div class="footer">
-      <div class="grid-12 gap-[12px] px-[16px]">
-        <div class="col-6 offset-3" uno-sm="col-6 offset-3">
-          <common-button-rounded
-            content="返回" bgc="#fff" color="#000" @button-click="() => {
-              router.back()
-            }" />
-        </div>
-      </div>
     </div>
   </div>
 </template>

--- a/pages/sale/sales/order.vue
+++ b/pages/sale/sales/order.vue
@@ -12,7 +12,7 @@ const { getFinishedWhere } = useFinished()
 const { finishedFilterList } = storeToRefs(useFinished())
 const { getOldWhere } = useOld()
 const { oldFilterList } = storeToRefs(useOld())
-const router = useRouter()
+
 const route = useRoute()
 if (route.query.id) {
   await getOrderDetail({ id: route.query.id as string })
@@ -43,16 +43,6 @@ const returnGoods = async (req: ReturnGoods) => {
         :product-filter="finishedFilterList"
         :orders="OrderDetail"
         :return-goods="returnGoods" />
-    </div>
-    <div class="footer">
-      <div class="grid-12 gap-[12px] px-[16px]">
-        <div class="col-6 offset-3" uno-sm="col-6 offset-3">
-          <common-button-rounded
-            content="返回" bgc="#fff" color="#000" @button-click="() => {
-              router.back()
-            }" />
-        </div>
-      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能移除**
  - 删除了部分页面底部的“返回”按钮，用户将无法通过该按钮返回上一页。
- **修复**
  - 修正了销售相关组件模板结构，新增了底部插槽以规范“查看详情”按钮的展示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->