### PR TITLE
feat: 修改新增销售单

### DIFF
--- a/components/sale/add/Depositorder.vue
+++ b/components/sale/add/Depositorder.vue
@@ -37,7 +37,7 @@ const cute = (index: number) => {
             </div>
           </div>
         </div>
-        <n-checkbox-group v-model:value="depositSelect">
+        <n-checkbox-group v-model:value="depositSelect" @update:value="handleBlur">
           <div>
             <template v-for="(item, index) in showDepositList" :key="index">
               <div class="flex-between items-start pb-[8px]">
@@ -47,9 +47,8 @@ const cute = (index: number) => {
                     :label="`订金金额${item.price_pay},订金单号:${item.id},${item.products[0].product_finished.name}`" :style="{
                       '--n-color-checked': '#1D6DEC',
                       '--n-border-focus': '#1D6DEC',
-                      '--n-border-checked': '#1D6DEC',
                       '--n-box-shadow-focus': '0 0 0 2px rgba(37, 115, 238, 0.3)',
-                    }" @blur="handleBlur" />
+                    }" />
                 </div>
                 <div
                   class="wh-[25px] flex-shrink-0 bg-[#fff] rounded-3xl flex-center-col border-[#2080F0] border-solid border text-[20px] "

--- a/components/sale/add/parts/Search.vue
+++ b/components/sale/add/parts/Search.vue
@@ -8,7 +8,6 @@ const Props = defineProps<{
   checkAccessoriesScore: (params: { classes: AccessorieCategory['type_part'][] }) => any
 }>()
 const showModal = defineModel('show', { default: false })
-const { $toast } = useNuxtApp()
 // 搜索商品 名称name 和 条码code   编号number
 const searchType = ref('number')
 const searchPartsVal = ref('')
@@ -86,8 +85,11 @@ const confirmParts = async () => {
   // 获取大类的比例
   const classArray = await Props.checkAccessoriesScore({ classes: arr.value })
   if (!classArray?.length) {
-    $toast.error('获取配件比例失败')
-    return
+    // $toast.error('获取配件比例失败')
+    // return
+    arr.value.forEach(() => {
+      classArray.push(0)
+    })
   }
 
   // 创建分类快速查询索引

--- a/components/sale/deposit/List.vue
+++ b/components/sale/deposit/List.vue
@@ -54,7 +54,7 @@ const jumpSaleOreder = (id: string) => {
         <template #footer>
           <div class="flex-between pl-[8px] bg-[#F3F5FE] rounded-b-[24px] dark:bg-[rgba(243,245,254,0.1)]">
             <div class="color-[#4287F4] cursor-pointer flex justify-center items-center">
-              <template v-if="item.status === DepositOrderStatus.Verified">
+              <template v-if="item.status === DepositOrderStatus.Booking">
                 <div class="pl-[8px] " @click="openOrder(item.id)">
                   开单
                 </div>

--- a/pages/sale/deposit/add.vue
+++ b/pages/sale/deposit/add.vue
@@ -73,6 +73,7 @@ const handleValidateButtonClick = async (e: MouseEvent) => {
       const res = await submitDepositOrder(formData.value)
       if (res?.code === HttpCode.SUCCESS) {
         $toast.success('下单成功')
+        navigateTo('/sale/deposit/list', { external: true, replace: true, redirectCode: 200 })
         formData.value = { ...initForm.value }
         showProductList.value = []
         Key.value = Date.now().toString()

--- a/pages/sale/deposit/list.vue
+++ b/pages/sale/deposit/list.vue
@@ -102,6 +102,10 @@ const submitCancel = async () => {
 const changeStores = async () => {
   await getList()
 }
+const router = useRouter()
+const newAdd = async () => {
+  await router.push('/sale/deposit/add')
+}
 </script>
 
 <template>
@@ -188,7 +192,7 @@ const changeStores = async () => {
         />
       </template>
     </common-filter-where>
-
+    <common-create @create="newAdd()" />
     <common-confirm v-model:show="payDialog" icon="success" title="支付提示" text="确认要完成支付吗?" @submit="submitPay" />
     <common-confirm v-model:show="cancelDialog" icon="error" title="撤销提示" text="确认撤销此订金单吗?" @submit="submitCancel" />
   </div>

--- a/pages/sale/other/add.vue
+++ b/pages/sale/other/add.vue
@@ -98,6 +98,7 @@ const handleValidateButtonClick = (e: any) => {
         const res = await addOtherOrder(formData.value)
         if (res?.value?.code === HttpCode.SUCCESS) {
           $toast.success('下单成功')
+          navigateTo('/sale/other/list', { external: true, replace: true, redirectCode: 200 })
           formData.value = { ...initForm.value }
           Key.value = Date.now().toString()
         }

--- a/pages/sale/other/list.vue
+++ b/pages/sale/other/list.vue
@@ -62,6 +62,10 @@ const confirmDel = async () => {
 const changeStores = async () => {
   await getList()
 }
+const router = useRouter()
+const newAdd = async () => {
+  await router.push('/sale/other/add')
+}
 </script>
 
 <template>
@@ -96,6 +100,7 @@ const changeStores = async () => {
         </div>
       </div>
     </div>
+    <common-create @create="newAdd()" />
     <common-confirm v-model:show="delDialog" icon="error" title="删除提醒" text="确认删除此收支单吗?" @submit="confirmDel" />
     <common-filter-where v-model:show="filterShow" :data="filterData" :filter="filterListToArray" @submit="submitWhere" @reset="resetWhere" />
   </div>

--- a/pages/sale/sales/add.vue
+++ b/pages/sale/sales/add.vue
@@ -184,9 +184,9 @@ const addProduct = async (product: ProductFinisheds) => {
   }
 }
 
-if (route.query.id) {
+if (route?.query?.id) {
   // 判断是否有定金单订单详情
-  await getOrderDetail({ id: route.query.id as string })
+  await getOrderDetail({ id: route?.query?.id as string })
   showDepositList.value.push(OrderDetail.value)
   OrderDetail.value.products.forEach((item) => {
     if (item.is_our) {
@@ -365,6 +365,7 @@ const handleValidateButtonClick = async (e: MouseEvent) => {
       const res = await submitOrder(formData.value)
       if (res?.code === HttpCode.SUCCESS) {
         $toast.success('开单成功')
+        navigateTo('/sale/sales/list', { external: true, replace: true, redirectCode: 200 })
         formData.value = { ...initFormData.value }
         showProductList.value = []
         showMasterialsList.value = []

--- a/pages/sale/sales/list.vue
+++ b/pages/sale/sales/list.vue
@@ -93,6 +93,10 @@ const payOrderConfirm = async (id: string) => {
 const changeStores = async () => {
   await getList()
 }
+const router = useRouter()
+const newAdd = async () => {
+  await router.push('/sale/sales/add')
+}
 </script>
 
 <template>
@@ -194,6 +198,7 @@ const changeStores = async () => {
         />
       </template>
     </common-filter-where>
+    <common-create @create="newAdd()" />
   </div>
 </template>
 

--- a/pages/sale/service/add.vue
+++ b/pages/sale/service/add.vue
@@ -117,6 +117,7 @@ const handleValidateButtonClick = async (e: MouseEvent) => {
       const res = await createRepairOrder(formData.value)
       if (res) {
         $toast.success('创建维修单成功')
+        navigateTo('/sale/service/list', { external: true, replace: true, redirectCode: 200 })
         showServiceGoods.value = []
         previewFileList.value = []
         formData.value = { ...initform.value }

--- a/pages/sale/service/list.vue
+++ b/pages/sale/service/list.vue
@@ -91,6 +91,10 @@ const setNowcity = () => {
   areaOptions.value = areaOptions.value[0].children
   Key.value = new Date().getTime().toString()
 }
+const router = useRouter()
+const newAdd = async () => {
+  await router.push('/sale/service/add')
+}
 </script>
 
 <template>
@@ -216,6 +220,7 @@ const setNowcity = () => {
         </template>
       </common-filter-where>
     </div>
+    <common-create @create="newAdd()" />
   </div>
 </template>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在销售列表页新增“创建”按钮，点击可跳转至新增销售单页面。
  * 在定金单列表页新增“创建”按钮，点击可跳转至新增定金单页面。
  * 在其他销售列表页新增“创建”按钮，点击可跳转至新增其他销售单页面。
  * 在维修服务列表页新增“创建”按钮，点击可跳转至新增维修单页面。

* **功能优化**
  * 提交销售单成功后，自动跳转回销售列表页。
  * 提交定金单成功后，自动跳转回定金单列表页。
  * 提交其他销售单成功后，自动跳转回其他销售列表页。
  * 提交维修单成功后，自动跳转回维修服务列表页。
  * 修改定金单卡片底部按钮的显示条件，仅在“预订中”状态下显示“开单”按钮。
  * 优化销售单新增页对路由参数的安全访问，避免潜在报错。

* **体验优化**
  * 定金单选择项交互优化，提升操作流畅度。
  * 配件选择流程调整，遇到校验失败时默认填充零值，避免中断操作。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->