### PR TITLE
fix: 修改[新增销售单,选择配件的应付金额]

### DIFF
--- a/components/sale/add/Parts.vue
+++ b/components/sale/add/Parts.vue
@@ -45,7 +45,6 @@ const rounding = roundFunction(Props.billingSet.rounding)
     <sale-add-parts-search
       v-model:show="showModal"
       v-model:list="showPartsList"
-      v-model:hold="hold"
       :is-integral="Props.isIntegral"
       :billing-set="Props.billingSet"
       :check-accessories-score="Props.checkAccessoriesScore"

--- a/components/sale/add/Parts.vue
+++ b/components/sale/add/Parts.vue
@@ -14,9 +14,9 @@ const emits = defineEmits<{
 
 const showPartsList = defineModel<ProductAccessories[]>('list', { default: [] })
 const showModal = ref(false)
-
 // 小数点进位计算函数
-const hold = ref(0)
+const hold = holdFunction(Props.billingSet.decimal_point)
+const rounding = roundFunction(Props.billingSet.rounding)
 </script>
 
 <template>
@@ -38,8 +38,9 @@ const hold = ref(0)
     </div>
 
     <sale-add-parts-list
-      v-model:hold="hold"
       v-model:list="showPartsList"
+      :hold="hold"
+      :rounding="rounding"
       :is-integral="Props.isIntegral" />
     <sale-add-parts-search
       v-model:show="showModal"

--- a/components/sale/add/parts/List.vue
+++ b/components/sale/add/parts/List.vue
@@ -69,7 +69,7 @@ const deleteConfirm = () => {
                       :show-button="false"
                       placeholder="请输入应付金额"
                       round
-                      :precision="hold"
+                      :precision="props.hold"
                       min="0"
                       @focus="focus"
                     >

--- a/components/sale/add/parts/List.vue
+++ b/components/sale/add/parts/List.vue
@@ -1,7 +1,10 @@
 <script lang="ts" setup>
 import { calc } from 'a-calc'
 
-const hold = defineModel<number>('hold', { default: 0 })
+const props = defineProps<{
+  rounding: string
+  hold: number
+}>()
 const showPartsList = defineModel<ProductAccessories[]>('list', { default: [] })
 const hasCheck = ref(false)
 
@@ -16,9 +19,11 @@ const deleteParts = (index: number) => {
 const changeQuantity = (obj: ProductAccessories) => {
   if (obj.quantity && obj.price) {
     // 计算应付金额
-    obj.amount = calc('(a * b)| =0 ~5, !n', {
-      a: obj.quantity || 1,
-      b: Number(obj.price) || 0,
+    const qty = obj.quantity ?? 1
+    const price = Number(obj.price ?? 0)
+    obj.amount = calc(`(a * b)| =${props.hold} ~${props.rounding}, !n`, {
+      a: qty,
+      b: price,
     })
   }
 }

--- a/components/sale/add/parts/List.vue
+++ b/components/sale/add/parts/List.vue
@@ -1,40 +1,10 @@
 <script lang="ts" setup>
 import { calc } from 'a-calc'
 
-const Props = defineProps<{
-  isIntegral: boolean
-}>()
+const hold = defineModel<number>('hold', { default: 0 })
 const showPartsList = defineModel<ProductAccessories[]>('list', { default: [] })
 const hasCheck = ref(false)
 
-// 改变配件数量
-const changeQuantity = (obj: ProductAccessories) => {
-  if (obj.price) {
-    // 计算应付金额
-    obj.amount = calc('(a * b)| =0 ~5, !n', {
-      a: obj.quantity || 1,
-      b: Number(obj.price) || 0,
-    })
-  }
-
-  if (obj.amount && obj.rate) {
-  // 计算积分
-    obj.integral = Props.isIntegral
-      ? calc('(a / b)| =0 ~5, !n', {
-          a: obj.amount,
-          b: obj.rate,
-        })
-      : 0
-  }
-}
-
-const itemPrice = (price?: string, quantity?: number) => {
-  const result = calc('(a * b)| =0 ~5, !n', {
-    a: quantity || 1,
-    b: Number(price) || 0,
-  })
-  return result
-}
 // 删除展示的配件
 const confirmShow = ref(false)
 const delId = ref(0)
@@ -42,7 +12,16 @@ const deleteParts = (index: number) => {
   confirmShow.value = true
   delId.value = index
 }
-
+// 改变配件数量
+const changeQuantity = (obj: ProductAccessories) => {
+  if (obj.quantity && obj.price) {
+    // 计算应付金额
+    obj.amount = calc('(a * b)| =0 ~5, !n', {
+      a: obj.quantity || 1,
+      b: Number(obj.price) || 0,
+    })
+  }
+}
 const deleteConfirm = () => {
   showPartsList.value.splice(delId.value, 1)
   delId.value = 0
@@ -65,16 +44,6 @@ const deleteConfirm = () => {
               <div class="h-[1px] bg-[#E6E6E8] dark:bg-[rgba(230,230,232,0.3)]" />
               <div class="pb-[16px]">
                 <n-grid :cols="24" :x-gap="8">
-                  <n-form-item-gi :span="12" label="积分( + )">
-                    <n-input-number
-                      v-model:value="obj.integral"
-                      :show-button="false"
-                      :disabled="true"
-                      min="0"
-                      placeholder="请输入积分"
-                      :default-value="Number(obj?.integral) || 0"
-                      round @focus="focus" />
-                  </n-form-item-gi>
                   <n-form-item-gi :span="12" label="数量">
                     <div class="flex items-center w-full">
                       <div class="w-full">
@@ -84,9 +53,25 @@ const deleteConfirm = () => {
                           min="1"
                           :precision="0"
                           :show-button="false"
-                          @focus="focus" @update:value="changeQuantity(obj)" />
+                          @focus="focus"
+                          @update:value="changeQuantity(obj)" />
                       </div>
                     </div>
+                  </n-form-item-gi>
+                  <n-form-item-gi :span="12" label="应付金额">
+                    <n-input-number
+                      v-model:value="obj.amount"
+                      :show-button="false"
+                      placeholder="请输入应付金额"
+                      round
+                      :precision="hold"
+                      min="0"
+                      @focus="focus"
+                    >
+                      <template #suffix>
+                        元
+                      </template>
+                    </n-input-number>
                   </n-form-item-gi>
                 </n-grid>
                 <div class="flex justify-between items-center">
@@ -94,10 +79,6 @@ const deleteConfirm = () => {
                     class="p-[8px] col-2 flex-center-row cursor-pointer"
                     @click="deleteParts(ix)">
                     <icon name="i-svg:delete" :size="16" />
-                  </div>
-                  <div>
-                    <span>应付金额:</span>
-                    <span>{{ itemPrice(obj?.price, obj.quantity) }}</span>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 新增“应付金额”输入框，按系统精度显示并支持取整规则，替换原有只读金额展示。

- 重构
  - 金额仅在数量和单价均填写时计算，默认数量为1，计算精度与取整规则同步父级设置。
  - 移除积分相关展示与逻辑，界面更简洁。
  - 保留并简化删除确认流程，防止误删。

- 变更
  - 组件间传参改为以精度与取整规则单向传入，使用方式调整以统一显示与计算逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->