### PR TITLE
feat: 新增[批量打印,配件显示总金额]

### DIFF
--- a/components/print/Board.vue
+++ b/components/print/Board.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { calc } from 'a-calc'
+
 const props = defineProps<{
   /**
    * 订单详情
@@ -77,6 +79,19 @@ const formartMoney = (money: number | string | undefined) => {
 
 findSalesman()
 judgeType()
+const partTotalPrice = computed(() => {
+  // 计算配件总价
+  let totalPrice = 0
+  props.details?.products?.forEach((item) => {
+    if (item.type === 3) {
+      totalPrice += calc('(a * b )| =3 ~5,!n', {
+        a: item?.accessorie.price,
+        b: item?.accessorie.quantity,
+      })
+    }
+  })
+  return totalPrice
+})
 </script>
 
 <template>
@@ -261,18 +276,27 @@ judgeType()
             </table>
           </template>
           <template v-if="hasAccessorie || !props.details">
-            <div>
-              <template v-for="(item, index) in props.details?.products" :key="index">
-                <template v-if="item.type === GoodsType.ProductAccessories">
-                  <span class="table-body">
-                    {{ item.accessorie.product?.name || '' }}
-                  </span>
-                  <span class="table-body">
-                    x{{ item.accessorie.quantity || '' }};
-                  </span>
-                </template>
-              </template>
-            </div>
+            <table cellspacing="0" class="table-header" style="width: 100%;">
+              <thead>
+                <tr>
+                  <th class="table-header" style=" width:auto;">
+                    <template v-for="(item, index) in props.details?.products" :key="index">
+                      <template v-if="item.type === GoodsType.ProductAccessories">
+                        <span class="table-body">
+                          {{ item.accessorie.product?.name || '' }}
+                        </span>
+                        <span class="table-body">
+                          x{{ item.accessorie.quantity || '' }};
+                        </span>
+                      </template>
+                    </template>
+                  </th>
+                  <th class="table-header" style=" width:16%;">
+                    {{ partTotalPrice }}
+                  </th>
+                </tr>
+              </thead>
+            </table>
           </template>
         </div>
       </template>

--- a/components/print/Board.vue
+++ b/components/print/Board.vue
@@ -90,7 +90,9 @@ const partTotalPrice = computed(() => {
       })
     }
   })
-  return totalPrice
+  return calc('(a)| =3 ~5,!n', {
+    a: totalPrice,
+  })
 })
 </script>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 打印页新增“配件总价”计算与展示，主单打印与退货打印两处可见，按配件单价与数量自动汇总，便于快速核对金额。
- 样式
  - 配件区域由逐项列表改为两列表格布局：左列显示配件名称与数量，右列显示对应总价；其他非配件内容与流程保持不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->