### PR TITLE
fix: 修复定金单跳转和抵扣金额显示问题

### DIFF
--- a/components/sale/add/Masterials.vue
+++ b/components/sale/add/Masterials.vue
@@ -4,6 +4,7 @@ const props = defineProps<{
   oldFilterList: Where<OrderMaterial>
   oldFilterListToArray: FilterWhere<OrderMaterial>[]
   billingSet: BillingSet
+  storeid: string
 }>()
 const { getOldClass, getOldScoreProportion } = useOld()
 // 获取旧料大类，并获取旧料积分比例
@@ -77,6 +78,7 @@ const editOld = (item: OrderMaterial, index: number) => {
         :check-old-class="CheckOldClass"
         :now-edit-state="nowEditState"
         :billing-set="props.billingSet"
+        :storeid="props.storeid"
       />
       <sale-add-masterials-handle
         v-model="orderObject"

--- a/components/sale/add/Settlement.vue
+++ b/components/sale/add/Settlement.vue
@@ -179,7 +179,7 @@ const searchRmk = async (query: string) => {
           <common-cell label="配件礼品" :value="PartsListMoney" />
           <common-cell label="旧料抵扣" :value="masterMoney" />
           <common-cell label="优惠金额" value="0" />
-          <common-cell label="订金抵扣" value="0" />
+          <common-cell label="订金抵扣" :value="depositMoney" />
           <common-cell label="积分合计：" :value="`销售(+${productListScore}) 旧料(-${masterListScore})  配件礼品(+${PartsListScore}) `" label-color="#3971F3" val-color="#3971F3" />
           <common-cell label="实际积分" :value="totalScore" label-color="#3971F3" val-color="#3971F3" />
           <common-cell label="实付金额" :value="payMoney" label-color="#3971F3" val-color="#3971F3" />

--- a/components/sale/add/Settlement.vue
+++ b/components/sale/add/Settlement.vue
@@ -37,7 +37,7 @@ const depositMoney = computed(() => {
   }, 0)
   return total.value
 })
-//
+
 // 计算成品列表金额
 const productMoney = computed(() => {
   const total = ref(0)
@@ -178,7 +178,7 @@ const searchRmk = async (query: string) => {
           <common-cell label="货品金额" :value="productMoney" />
           <common-cell label="配件礼品" :value="PartsListMoney" />
           <common-cell label="旧料抵扣" :value="masterMoney" />
-          <common-cell label="优惠金额" value="0" />
+          <!-- <common-cell label="优惠金额" value="0" /> -->
           <common-cell label="订金抵扣" :value="depositMoney" />
           <common-cell label="积分合计：" :value="`销售(+${productListScore}) 旧料(-${masterListScore})  配件礼品(+${PartsListScore}) `" label-color="#3971F3" val-color="#3971F3" />
           <common-cell label="实际积分" :value="totalScore" label-color="#3971F3" val-color="#3971F3" />

--- a/components/sale/add/masterials/Search.vue
+++ b/components/sale/add/masterials/Search.vue
@@ -17,7 +17,7 @@ const { getFinishedRetrieval } = useFinished()
 const searchOlds = async (val: string) => {
   if (val) {
     const data = await getFinishedRetrieval(val, props.storeid)
-    if (data?.code === HttpCode.SUCCESS && data?.data?.status === 5) {
+    if (data?.code === HttpCode.SUCCESS && data?.data?.status === GoodsStatus.ProductStatusSold) {
       const params = data.data
       OldObj.value = params
       OldObj.value.product_id = params.id

--- a/components/sale/add/masterials/Search.vue
+++ b/components/sale/add/masterials/Search.vue
@@ -8,15 +8,24 @@ const props = defineProps<{
   price: GoldPrices[]
   billingSet: BillingSet
   oldFilterList: Where<OrderMaterial>
+  storeid: string
 }>()
 const { $toast } = useNuxtApp()
-const { getOldList } = useOrder()
+const { OldObj } = storeToRefs(useOrder())
+const { getFinishedRetrieval } = useFinished()
 // 搜索旧料
 const searchOlds = async (val: string) => {
   if (val) {
-    const res = await getOldList({ page: 1, limit: 10, where: { code: val, status: ProductFinishedsStatus.Sold } })
-    if (Object.keys(res).length === 0) {
-      $toast.error('没有找到旧料')
+    const data = await getFinishedRetrieval(val, props.storeid)
+    if (data?.code === HttpCode.SUCCESS && data.data.status === 5) {
+      const params = data.data
+      OldObj.value = params
+      OldObj.value.product_id = params.id
+      OldObj.value.weight_metal = Number(params.weight_metal)
+      OldObj.value.code_finished = params.code
+    }
+    else {
+      $toast.error(data?.message || '没有找到旧料')
     }
   }
 }

--- a/components/sale/add/masterials/Search.vue
+++ b/components/sale/add/masterials/Search.vue
@@ -17,7 +17,7 @@ const { getFinishedRetrieval } = useFinished()
 const searchOlds = async (val: string) => {
   if (val) {
     const data = await getFinishedRetrieval(val, props.storeid)
-    if (data?.code === HttpCode.SUCCESS && data.data.status === 5) {
+    if (data?.code === HttpCode.SUCCESS && data?.data?.status === 5) {
       const params = data.data
       OldObj.value = params
       OldObj.value.product_id = params.id

--- a/components/sale/deposit/List.vue
+++ b/components/sale/deposit/List.vue
@@ -5,6 +5,7 @@ const props = defineProps<{
   where: Where<DepositOrderWhere>
   isStoreStaff: () => Promise<boolean>
 }>()
+const { orderObject } = storeToRefs(useOrder())
 const { $toast } = useNuxtApp()
 const handleClick = (id?: string) => {
   if (!id) {
@@ -22,6 +23,7 @@ const openOrder = async (id?: string) => {
     $toast.error('未入职门店无法操作')
     return
   }
+  orderObject.value = {} as Orders
   navigateTo(`/sale/sales/add?id=${id}`)
 }
 const jumpSaleOreder = (id: string) => {

--- a/components/sale/deposit/List.vue
+++ b/components/sale/deposit/List.vue
@@ -5,7 +5,8 @@ const props = defineProps<{
   where: Where<DepositOrderWhere>
   isStoreStaff: () => Promise<boolean>
 }>()
-const { orderObject } = storeToRefs(useOrder())
+
+const { initObjForm } = useOrder()
 const { $toast } = useNuxtApp()
 const handleClick = (id?: string) => {
   if (!id) {
@@ -23,7 +24,7 @@ const openOrder = async (id?: string) => {
     $toast.error('未入职门店无法操作')
     return
   }
-  orderObject.value = {} as Orders
+  initObjForm()
   navigateTo(`/sale/sales/add?id=${id}`)
 }
 const jumpSaleOreder = (id: string) => {

--- a/pages/sale/sales/add.vue
+++ b/pages/sale/sales/add.vue
@@ -280,6 +280,7 @@ onMounted(async () => {
             :old-filter-list="oldFilterList"
             :old-filter-list-to-array="oldFilterListToArray"
             :billing-set="billingSet"
+            :storeid="myStore.id"
           />
           <sale-add-parts
             v-model="orderObject"

--- a/pages/sale/sales/add.vue
+++ b/pages/sale/sales/add.vue
@@ -218,15 +218,6 @@ const tipFormVisible = () => {
   })?.length > 0)
 }
 
-if (route?.query?.id) {
-  // 判断是否有定金单订单详情
-  await getOrderDetail({ id: route?.query?.id as string })
-  showDepositList.value.push(OrderDetail.value)
-  updateDepostitProduct()
-  await nextTick()
-  addMemberRef.value?.setMbid(OrderDetail.value.member_id, OrderDetail.value.member?.phone)
-}
-
 const initFinished = ref(false)
 const loading = ref(true)
 onMounted(async () => {
@@ -235,6 +226,15 @@ onMounted(async () => {
   initOptions()
   initFinished.value = true
   loading.value = false
+
+  if (route?.query?.id) {
+  // 判断是否有定金单订单详情
+    await getOrderDetail({ id: route?.query?.id as string })
+    showDepositList.value.push(OrderDetail.value)
+    updateDepostitProduct()
+    await nextTick()
+    addMemberRef.value?.setMbid(OrderDetail.value.member_id, OrderDetail.value.member?.phone)
+  }
 })
 </script>
 


### PR DESCRIPTION
修复从定金单跳转至销售订单时未清空订单对象的问题
修正结算页面中定金抵扣金额未正确显示的问题
将定金单详情加载逻辑移至onMounted中确保初始化完成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - 结算信息中“优惠金额”已隐藏，“订金抵扣”改为动态显示，数值与支付计算保持一致，避免显示固定为0。
  - 进入新增订单页前会初始化/重置订单表单，防止沿用残留数据导致异常。
  - 优化页面挂载时序：携带订金的销售单详情按正确顺序加载并展示。

- New Features
  - 为物料/旧料搜索引入门店标识支持；检索由单项获取并映射到表单以便显示，检索失败时显示友好错误提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->