### PR TITLE
feat: 货品图片展示

### DIFF
--- a/components/common/avatar/Index.vue
+++ b/components/common/avatar/Index.vue
@@ -26,16 +26,16 @@ const props = withDefaults(defineProps<{
 <template>
   <div>
     <template v-if="props.img">
-      <img
+      <n-image
         :src="props.img"
         class="w-full h-full shadow-[-3px_3px_0px_-1px_rgba(56,101,258,.8)]"
+        :width="props.size"
+        :height="props.size"
         :style="{
-          width: `${props.size}px`,
-          height: `${props.size}px`,
           borderRadius: props.rounded,
           boxShadow: props.hasShadow ? '-4 4px 0px 1px rgba(56,101,258,.8)' : 'none',
         }"
-      >
+      />
     </template>
     <template v-else>
       <div

--- a/components/product/manage/info.vue
+++ b/components/product/manage/info.vue
@@ -16,7 +16,12 @@ const props = defineProps<{
     <template #body>
       <div class="whitespace-nowrap overflow-x-auto flex gap-4" style=" ">
         <template v-for="(img, index) in info.images" :key="index">
-          <img class="shrink-0" :src="ImageUrl(img)" width="100" height="100">
+          <n-image
+            :src="ImageUrl(img)"
+            width="100"
+            height="100"
+            class="shrink-0"
+          />
         </template>
       </div>
       <div class="flex flex-col gap-3 px-4 py-3" uno-sm="grid grid-cols-[1fr_1fr] gap-x-8">

--- a/components/sale/order/Detail.vue
+++ b/components/sale/order/Detail.vue
@@ -124,14 +124,16 @@ const onReturnProduct = async (index: number) => {
               <div class="info">
                 <template v-if="obj.finished.product?.images?.length">
                   <div class="flex overflow-x-auto">
-                    <template v-for="(img, index) in obj.finished.product.images" :key="index">
-                      <n-image
-                        :src="ImageUrl(img)"
-                        width="100"
-                        height="100"
-                        class="shrink-0 p-1"
-                      />
-                    </template>
+                    <n-image-group>
+                      <template v-for="(img, index) in obj.finished.product.images" :key="index">
+                        <n-image
+                          :src="ImageUrl(img)"
+                          width="100"
+                          height="100"
+                          class="shrink-0 p-1"
+                        />
+                      </template>
+                    </n-image-group>
                   </div>
                 </template>
                 <common-cell label="商品条码" :value="obj.finished.product?.code" />
@@ -168,17 +170,19 @@ const onReturnProduct = async (index: number) => {
           <sale-cards title="旧料信息">
             <template #info>
               <div class="info">
-                <template v-if="obj.finished.product?.images?.length">
-                  <div class="flex overflow-x-auto">
-                    <template v-for="(img, index) in obj.finished.product.images" :key="index">
-                      <n-image
-                        :src="ImageUrl(img)"
-                        width="100"
-                        height="100"
-                        class="shrink-0 p-1"
-                      />
-                    </template>
-                  </div>
+                <template v-if="obj.old?.product?.images?.length">
+                  <n-image-group>
+                    <div class="flex overflow-x-auto">
+                      <template v-for="(img, index) in obj.old.product.images" :key="index">
+                        <n-image
+                          :src="ImageUrl(img)"
+                          width="100"
+                          height="100"
+                          class="shrink-0 p-1"
+                        />
+                      </template>
+                    </div>
+                  </n-image-group>
                 </template>
                 <common-cell label="旧料名称" :value="obj.old?.product?.name " val-color="#4C8DF6" />
                 <common-cell label="旧料编号" :value="obj?.old.product_id" />

--- a/components/sale/order/Detail.vue
+++ b/components/sale/order/Detail.vue
@@ -122,6 +122,18 @@ const onReturnProduct = async (index: number) => {
           <sale-cards title="成品信息">
             <template #info>
               <div class="info">
+                <template v-if="obj.finished.product?.images?.length">
+                  <div class="flex overflow-x-auto">
+                    <template v-for="(img, index) in obj.finished.product.images" :key="index">
+                      <n-image
+                        :src="ImageUrl(img)"
+                        width="100"
+                        height="100"
+                        class="shrink-0 p-1"
+                      />
+                    </template>
+                  </div>
+                </template>
                 <common-cell label="商品条码" :value="obj.finished.product?.code" />
                 <common-cell label="商品名称" :value="obj.finished.product?.name" val-color="#4C8DF6" />
                 <common-cell label="零售方式" :value="props.productFilter.retail_type?.preset[(obj.finished.product?.retail_type as number)]" />
@@ -156,6 +168,18 @@ const onReturnProduct = async (index: number) => {
           <sale-cards title="旧料信息">
             <template #info>
               <div class="info">
+                <template v-if="obj.finished.product?.images?.length">
+                  <div class="flex overflow-x-auto">
+                    <template v-for="(img, index) in obj.finished.product.images" :key="index">
+                      <n-image
+                        :src="ImageUrl(img)"
+                        width="100"
+                        height="100"
+                        class="shrink-0 p-1"
+                      />
+                    </template>
+                  </div>
+                </template>
                 <common-cell label="旧料名称" :value="obj.old?.product?.name " val-color="#4C8DF6" />
                 <common-cell label="旧料编号" :value="obj?.old.product_id" />
                 <common-cell label="旧料条码" :value="obj?.old.product?.code " />

--- a/pages/product/history/list.vue
+++ b/pages/product/history/list.vue
@@ -335,7 +335,14 @@ async function downloadLocalFile() {
         <template v-if="showtype === 'list'">
           <product-manage-card :list="productRocordList">
             <template #top="{ info }">
-              <div>{{ historyFilterList.action?.preset[info.action] }}</div>
+              <div class="flex items-center">
+                <template v-if="info?.new_value?.images?.length">
+                  <common-avatar :size="24" :img="info?.new_value?.images[0]" />
+                </template>
+                <div class="pl-2">
+                  {{ historyFilterList.action?.preset[info.action] }}
+                </div>
+              </div>
             </template>
             <template #info="{ info }">
               <div class="px-[16px] py-[8px] text-size-[14px] line-height-[20px] text-black dark:text-[#FFF]">

--- a/types/old.d.ts
+++ b/types/old.d.ts
@@ -172,5 +172,5 @@ interface ProductOlds {
    */
   rate: number | string
   supplier: number
-  images: string
+  images: string[]
 }

--- a/types/old.d.ts
+++ b/types/old.d.ts
@@ -172,4 +172,5 @@ interface ProductOlds {
    */
   rate: number | string
   supplier: number
+  images: string
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 订单详情的成品信息与旧料信息新增图片画廊，支持横向滚动缩略图预览。
  - 产品历史列表的操作项可显示首张图片作为头像，信息更直观。
- 改进
  - 头像与产品图片统一改为更稳定的图片组件，支持尺寸属性控制与更佳展示效果。
- 样式
  - 历史列表顶部区域调整为紧凑的左右排布，提升可读性与对齐。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->