### PR TITLE
fix: 处理打印报表时的错误处理和空数据情况

### DIFF
--- a/components/print/Statement.vue
+++ b/components/print/Statement.vue
@@ -286,7 +286,7 @@ const refundData = computed(() =>
           </tbody>
         </table>
       </template>
-      <template v-if="Number(printData.summary.sales_refund) > 0">
+      <template v-if="Number(printData?.summary?.sales_refund) > 0">
         <table class="w-full fixed-table" :style="{ 'font-size': props.font }">
           <thead>
             <tr>

--- a/pages/summary/sales_detail.vue
+++ b/pages/summary/sales_detail.vue
@@ -82,7 +82,11 @@ const printFn = () => {
 // 定义查询报表的方法
 const SearchResult = async () => {
   // 调用打印报表汇总数据的方法
-  await PrintSattementTotal(model.value)
+  const res = await PrintSattementTotal(model.value)
+  if (res?.code !== HttpCode.SUCCESS) {
+    $toast.error(res?.message || '获取数据失败')
+    return
+  }
   checkTime.value = new Date().toISOString()
 }
 

--- a/stores/statement.ts
+++ b/stores/statement.ts
@@ -102,8 +102,11 @@ export const useStatement = defineStore('statement', {
         const { data } = await https.post<StatisticSalesDetailDailyResp, PrintSattementTotalReq>('/statistic/sales_detail_daily', pamars)
         if (data.value?.code === HttpCode.SUCCESS) {
           this.printData = data.value.data
-          return data.value.data
         }
+        else {
+          this.printData = {} as StatisticSalesDetailDailyResp
+        }
+        return data.value
       }
       catch (error) {
         throw new Error(`获取货品列表失败: ${error || '未知错误'}`)


### PR DESCRIPTION
在PrintSattementTotal调用后添加错误处理，当返回码非成功时显示错误提示
修复Statement组件中printData可能为空的判断逻辑
在statement.ts中处理接口返回错误时初始化空数据

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 销售明细查询在接口失败时弹出错误提示并停止后续处理，提升反馈与可用性。
- 缺陷修复
  - 打印对账单在销售退款数据缺失时不再报错，相关区块将自动隐藏，避免渲染异常。
- 重构
  - 优化数据返回的一致性，结果状态更明确，有助于提升整体稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->