### PR TITLE
style: 调整浅色模式下表格单元格背景色为#D9E4F4

### DIFF
--- a/components/summary/Table.vue
+++ b/components/summary/Table.vue
@@ -147,7 +147,7 @@ const option = computed(() => {
         <n-data-table
           :style="{
             '--n-merged-th-color': $colorMode.value === 'light' ? '#C7DAFF' : '#1A6BEB',
-            '--n-merged-td-color': $colorMode.value === 'light' ? 'rgba(0,0,0,0)' : '#224879',
+            '--n-merged-td-color': $colorMode.value === 'light' ? '#D9E4F4' : '#224879',
             '--n-merged-border-color': 'rgba(57,113,243,0.08)',
           }"
           :columns="props.title"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 样式
  * 优化浅色模式下数据表格的视觉效果：单元格背景由透明调整为浅蓝色，提升可读性与层次区分。
  * 深色模式外观保持不变，无功能性改动。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->