### PR TITLE
feat: 新增今日收支统计

### DIFF
--- a/components/common/tabbar/Index.vue
+++ b/components/common/tabbar/Index.vue
@@ -34,7 +34,7 @@ const modeFun = () => {
 </script>
 
 <template>
-  <div class="fixed bottom-0 left-0 flex-center-row w-full" uno-lg="h-full w-auto">
+  <div class="fixed bottom-0 left-0 flex-center-row w-full z-3" uno-lg="h-full w-auto">
     <div
       class="w-full bg-[#F8FAFF] dark:bg-[#515862] text-[12px] pt-[12px] pb-[18px] px-[40px] flex-between"
       uno-lg="w-auto px-8px py-12px flex-center-col rounded-8px">

--- a/components/summary/Table.vue
+++ b/components/summary/Table.vue
@@ -110,7 +110,7 @@ const option = computed(() => {
 
 <template>
   <n-spin :show="props.loading" stroke="#fff" size="large">
-    <div class="blur-bgc rounded-[16px]  overflow-hidden mb-[16px]" data-allow-mismatch="style">
+    <div class="bg-[#DEEBFD] dark:bg-[rgba(0,0,0,0.3)]  rounded-[16px]  overflow-hidden mb-[16px]" data-allow-mismatch="style">
       <div class=" rounded-[4px]">
         <div class="grid-12 pb-[16px]">
           <div
@@ -152,7 +152,7 @@ const option = computed(() => {
         <n-data-table
           :style="{
             '--n-merged-th-color': $colorMode.value === 'light' ? '#C7DAFF' : '#1A6BEB',
-            '--n-merged-td-color': $colorMode.value === 'light' ? '#D9E4F4' : '#224879',
+            '--n-merged-td-color': $colorMode.value === 'light' ? '#DEEBFD' : '#224879',
             '--n-merged-border-color': 'rgba(57,113,243,0.08)',
           }"
           :columns="props.title"

--- a/components/summary/Table.vue
+++ b/components/summary/Table.vue
@@ -8,6 +8,10 @@ const props = withDefaults(defineProps<{
 }>(), {
   isToggle: true,
 })
+
+const emits = defineEmits<{
+  clickTitle: []
+}>()
 const { $colorMode } = useNuxtApp()
 const scrollX = ref(0)
 
@@ -110,7 +114,8 @@ const option = computed(() => {
       <div class=" rounded-[4px]">
         <div class="grid-12 pb-[16px]">
           <div
-            class="skew col-6" uno-md="col-4">
+            class="skew col-6"
+            uno-md="col-4" @click="emits('clickTitle')">
             <div class="skew-right" />
             <div class="skew-text pl-[15px] text-[16px] font-semibold">
               <div class="flex-center-row h-full">

--- a/components/summary/Table.vue
+++ b/components/summary/Table.vue
@@ -44,7 +44,7 @@ const option = computed(() => {
     },
     legend: {
       data: props.title
-        .filter((item: StockTitle) => item.title !== '门店' && item.title !== '合计')
+        .filter((item: StockTitle) => item.title !== '门店' && item.title !== '合计' && item.title !== '支付方式')
         .map((item: StockTitle) => item.title),
       left: 'center',
       top: 10,
@@ -114,7 +114,7 @@ const option = computed(() => {
       <div class=" rounded-[4px]">
         <div class="grid-12 pb-[16px]">
           <div
-            class="skew col-6"
+            class="skew col-6 cursor-pointer"
             uno-md="col-4" @click="emits('clickTitle')">
             <div class="skew-right" />
             <div class="skew-text pl-[15px] text-[16px] font-semibold">

--- a/components/summary/boss/Card.vue
+++ b/components/summary/boss/Card.vue
@@ -8,6 +8,7 @@ const props = defineProps<{
 }>()
 const emits = defineEmits<{
   getlist: []
+  clickTitle: []
 }>()
 
 const radio = defineModel<BossWhere['type']>({ default: 1 })
@@ -16,7 +17,7 @@ const toggleChart = ref<'list' | 'chart'>('list')
 
 <template>
   <div>
-    <summary-table v-model="toggleChart" :loading="props.loading" :title="props.title" :list="props.list">
+    <summary-table v-model="toggleChart" :loading="props.loading" :title="props.title" :list="props.list" @click-title="emits('clickTitle')">
       <template #header-title>
         {{ props.cardTitle }}
       </template>

--- a/components/summary/boss/SelectTime.vue
+++ b/components/summary/boss/SelectTime.vue
@@ -1,8 +1,11 @@
 <script lang="ts" setup>
+const props = defineProps<{
+  timeWhere?: Where<CashflowWhere> | Where<BossWhere>
+}>()
 const emits = defineEmits<{
   updateTime: []
 }>()
-const { timeWhere } = storeToRefs(useBoss())
+
 const startTime = ref()
 const endTime = ref()
 const params = defineModel<BossWhere>({ default: { } as BossWhere })
@@ -33,7 +36,7 @@ const cofirmTime = async () => {
         placeholder="请选择时间范围"
         clearable
         remote
-        :options="optonsToSelect(timeWhere.duration?.preset ?? [])"
+        :options="optonsToSelect(props.timeWhere?.duration?.preset ?? [])"
         @update:value="selectDuration" />
     </div>
     <div class="col-12" uno-sm="col-8">

--- a/components/summary/card/Inventory.vue
+++ b/components/summary/card/Inventory.vue
@@ -27,7 +27,7 @@ const TodayInventoryList = ref<DataCardList<TodayInventory>>({
 </script>
 
 <template>
-  <div class="blur-bgc rounded-[16px]  cursor-pointer" :style="{ marginBottom: props.marginBottom }">
+  <div class="bg-[#DEEBFD] dark:bg-[rgba(0,0,0,0.3)]  rounded-[16px]  cursor-pointer" :style="{ marginBottom: props.marginBottom }">
     <div class="grid-12">
       <div
         class="skew col-6" uno-md="col-4">

--- a/components/summary/card/Payment.vue
+++ b/components/summary/card/Payment.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{
+  rbText?: string
+  marginBottom?: string
+  goldPrice?: string
+  payments: Record<string, string>
+}>(), {
+  rbText: '查看排行',
+  marginBottom: '16px',
+})
+
+const id = useId()
+const { run, stop } = addMouseEvent(`#${id}`)
+onMounted(() => {
+  run()
+})
+onBeforeUnmount(() => {
+  stop()
+})
+</script>
+
+<template>
+  <div class="blur-bgc rounded-[16px]  cursor-pointer" :style="{ marginBottom: props.marginBottom }">
+    <div class="grid-12">
+      <div
+        class="skew col-6" uno-md="col-4">
+        <div class="skew-right" />
+        <div class="skew-text pl-[15px] text-[16px] font-semibold">
+          <div class="flex-center-row h-full">
+            今日收支
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="p-[16px] ">
+      <div :id="id" class="flex overflow-x-scroll gap-[20px]">
+        <template v-for="(item, key) in props.payments" :key="item">
+          <div class="flex-grow-1 flex-shrink-0">
+            <div class="flex-start">
+              <div class="w-[4px] h-[10px] bg-gradient-linear-[180deg,#1A6BEB,#6EA6FF] rounded-[2px]" />
+              <div class="color-[#333] dark:color-[#fff] ml-[4px] text-[12px]  line-height-[24px]">
+                {{ key }}
+              </div>
+            </div>
+            <div class="color-[#3971F3] dark:color-[#fff] font-semibold  line-height-[24px]">
+              <span class="text-[16px]">{{ item }}</span>
+            </div>
+          </div>
+        </template>
+      </div>
+      <div class="bg-[#c7dafF] dark:opacity-[0.5] h-[1px] w-full mt-[8px]" />
+      <div class="mt-[12px] flex-between">
+        <div />
+        <div class="color-[#333]  dark:color-[#fff] text-[12px] line-height-[24px] flex" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+::-webkit-scrollbar {
+  /* 隐藏Webkit浏览器的滚动条 */
+  display: none;
+}
+.skew-text {
+  display: flex;
+  align-items: flex-start;
+}
+</style>

--- a/components/summary/card/Payment.vue
+++ b/components/summary/card/Payment.vue
@@ -24,7 +24,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="blur-bgc rounded-[16px]  cursor-pointer" :style="{ marginBottom: props.marginBottom }">
+  <div class="bg-[#DEEBFD] dark:bg-[rgba(0,0,0,0.3)]  rounded-[16px] cursor-pointer" :style="{ marginBottom: props.marginBottom }">
     <div class="grid-12">
       <div
         class="skew col-6"

--- a/components/summary/card/Payment.vue
+++ b/components/summary/card/Payment.vue
@@ -9,6 +9,10 @@ const props = withDefaults(defineProps<{
   marginBottom: '16px',
 })
 
+const emit = defineEmits<{
+  clickTitle: []
+}>()
+
 const id = useId()
 const { run, stop } = addMouseEvent(`#${id}`)
 onMounted(() => {
@@ -23,7 +27,8 @@ onBeforeUnmount(() => {
   <div class="blur-bgc rounded-[16px]  cursor-pointer" :style="{ marginBottom: props.marginBottom }">
     <div class="grid-12">
       <div
-        class="skew col-6" uno-md="col-4">
+        class="skew col-6"
+        uno-md="col-4" @click="emit('clickTitle')">
         <div class="skew-right" />
         <div class="skew-text pl-[15px] text-[16px] font-semibold">
           <div class="flex-center-row h-full">

--- a/components/summary/card/Sale.vue
+++ b/components/summary/card/Sale.vue
@@ -31,7 +31,7 @@ const toTodayPrice = () => {
 </script>
 
 <template>
-  <div class="blur-bgc rounded-[16px]  cursor-pointer" :style="{ marginBottom: props.marginBottom }">
+  <div class="bg-[#DEEBFD] dark:bg-[rgba(0,0,0,0.3)]  rounded-[16px]  cursor-pointer" :style="{ marginBottom: props.marginBottom }">
     <div class="grid-12">
       <div
         class="skew col-6" uno-md="col-4">

--- a/components/summary/cashflow/Card.vue
+++ b/components/summary/cashflow/Card.vue
@@ -1,0 +1,48 @@
+<script lang="ts" setup>
+const props = defineProps<{
+  title: any[]
+  list?: BossSalesList[]
+  cardTitle: string
+  where?: Where<BossWhere>
+  loading: boolean
+}>()
+const emits = defineEmits<{
+  getlist: []
+  clickTitle: []
+}>()
+const { overview } = storeToRefs(useCashflow())
+const toggleChart = ref<'list' | 'chart'>('list')
+</script>
+
+<template>
+  <div>
+    <summary-table v-model="toggleChart" :loading="props.loading" :title="props.title" :list="props.list" @click-title="emits('clickTitle')">
+      <template #header-title>
+        {{ props.cardTitle }}
+      </template>
+      <template #select>
+        <div class="p-[16px] pt-0">
+          <div class="grid-12">
+            <template v-for="(item, key) in overview" :key="item">
+              <div class="col-4 ">
+                <div class="flex-start">
+                  <div class="w-[4px] h-[10px] bg-gradient-linear-[180deg,#1A6BEB,#6EA6FF] rounded-[2px]" />
+                  <div class="color-[#333] dark:color-[#fff] ml-[4px] text-[12px]  line-height-[24px]">
+                    {{ key }}
+                  </div>
+                </div>
+                <div class="color-[#3971F3] dark:color-[#fff] font-semibold  line-height-[24px]">
+                  <span class="text-[16px]">{{ item }}</span>
+                </div>
+              </div>
+            </template>
+          </div>
+        </div>
+      </template>
+    </summary-table>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+
+</style>

--- a/components/summary/cashflow/Card.vue
+++ b/components/summary/cashflow/Card.vue
@@ -16,7 +16,7 @@ const toggleChart = ref<'list' | 'chart'>('list')
 
 <template>
   <div>
-    <summary-table v-model="toggleChart" :loading="props.loading" :title="props.title" :list="props.list" @click-title="emits('clickTitle')">
+    <summary-table v-model="toggleChart" :is-toggle="false" :loading="props.loading" :title="props.title" :list="props.list" @click-title="emits('clickTitle')">
       <template #header-title>
         {{ props.cardTitle }}
       </template>

--- a/pages/index/index.vue
+++ b/pages/index/index.vue
@@ -3,8 +3,8 @@ useSeoMeta({
   title: '待办',
 })
 
-const { myStoreTodaySale, myStoreTodayInventory } = homeDataStore()
-const { TodayInventory, todaySaleData } = storeToRefs(homeDataStore())
+const { myStoreTodaySale, myStoreTodayInventory, myStoreTodayPayment } = homeDataStore()
+const { TodayInventory, todaySaleData, Payments } = storeToRefs(homeDataStore())
 const { myStore, myStoreList } = storeToRefs(useStores())
 const { getMyStore, switchStore } = useStores()
 const { getPerformanceType, getPerformanceList } = useBoss()
@@ -24,6 +24,7 @@ const handleSelectFn = async (id: Stores['id']) => {
 
 await myStoreTodayInventory({ store_id: myStore.value.id })
 await myStoreTodaySale({ store_id: myStore.value.id })
+await myStoreTodayPayment({ store_id: myStore.value.id })
 
 // 业绩
 const params = ref({ duration: 1 } as BossWhere)
@@ -66,6 +67,9 @@ onMounted(async () => {
           }" />
 
         <!-- <home-action /> -->
+        <template v-if="Payments">
+          <summary-card-payment :payments="Payments" />
+        </template>
         <template v-if="todaySaleData">
           <summary-card-sale :today-sale-data="todaySaleData" />
         </template>
@@ -77,7 +81,8 @@ onMounted(async () => {
           :title="performanceTitle"
           :list="performanceList"
           :loading="PerformanceLoading"
-          @getlist="getPerformanceListFn" />
+          @getlist="getPerformanceListFn"
+          @click-title="jump('/summary/boss')" />
       </template>
       <template v-else>
         <common-emptys text="暂未分配门店" />

--- a/pages/index/index.vue
+++ b/pages/index/index.vue
@@ -68,7 +68,7 @@ onMounted(async () => {
 
         <!-- <home-action /> -->
         <template v-if="Payments">
-          <summary-card-payment :payments="Payments" />
+          <summary-card-payment :payments="Payments" @click-title="jump('/summary/cashflow')" />
         </template>
         <template v-if="todaySaleData">
           <summary-card-sale :today-sale-data="todaySaleData" />

--- a/pages/summary/boss/index.vue
+++ b/pages/summary/boss/index.vue
@@ -4,9 +4,9 @@ useSeoMeta({
 })
 const { getPerformanceType, getPerformanceList, getPublicWhere, getOldSalesList, getOldSalesType, getFinishedSalesType, getFinishedSalesList, getStockList, getStockType, OldGetStockType, OldGetStockList, getRevenueList, getRevenueWhere } = useBoss()
 const { RevenueWhere, finishedSalesWhere, oldfilterWhere, oldSalesFilterWhere, finishedWhere } = storeToRefs(useBoss())
+const { timeWhere } = storeToRefs(useBoss())
 const params = ref({} as BossWhere)
 await getPublicWhere()
-
 // 读取url参数,获取列表
 const route = useRoute()
 const handleQueryParams = async () => {
@@ -158,7 +158,7 @@ onMounted(async () => {
       <div class="px-[16px]">
         <div class="flex justify-between items-center py-[12px] text-[#FFF]" />
         <!-- 时间选择器 -->
-        <summary-boss-select-time v-model="params" @update-time="updateTimeFn" />
+        <summary-boss-select-time v-model="params" :time-where="timeWhere" @update-time="updateTimeFn" />
         <!-- 性能统计 -->
         <summary-boss-card
           card-title="业绩统计"

--- a/pages/summary/cashflow/index.vue
+++ b/pages/summary/cashflow/index.vue
@@ -1,0 +1,85 @@
+<script lang="ts" setup>
+useSeoMeta({
+  title: '收支数据',
+})
+const { getPublicWhere, getCashflowList } = useCashflow()
+const { timeWhere } = storeToRefs(useCashflow())
+const params = ref({} as CashflowWhere)
+await getPublicWhere()
+
+// 读取url参数,获取列表
+const route = useRoute()
+const handleQueryParams = async () => {
+  params.value = {} as CashflowWhere
+  if (route.query?.duration) {
+    params.value.duration = Number(route.query?.duration)
+  }
+  else {
+    params.value.duration = 1
+  }
+  if (route.query?.startTime) {
+    params.value.startTime = route.query?.startTime as string
+  }
+  if (route.query?.endTime) {
+    params.value.endTime = route.query?.endTime as string
+  }
+}
+await handleQueryParams()
+
+const listJump = () => {
+  const url = UrlAndParams('/summary/cashflow', params.value)
+  navigateTo(url, { external: true, replace: true, redirectCode: 200 })
+}
+
+// 业绩统计初始化
+const cashflowLoading = ref<boolean>(false)
+const cashflowTitle = ref<StockTitle[]>([])
+const cashflowList = ref<BossSalesList[]>([])
+cashflowLoading.value = true
+const getcashflowListFn = async () => {
+  const res = await getCashflowList({ ...params.value })
+  cashflowTitle.value = res?.title || []
+  cashflowList.value = res?.list.sort((a, b) => {
+    // 将合计项提到最前面
+    if (a.name === '合计')
+      return -1
+    if (b.name === '合计')
+      return 1
+    return 0
+  }) || []
+  cashflowLoading.value = false
+}
+const getCashflowReq = async () => {
+  await getcashflowListFn()
+}
+
+const updateTimeFn = () => {
+  listJump()
+}
+onMounted(async () => {
+  await nextTick()
+  await getCashflowReq()
+})
+</script>
+
+<template>
+  <div>
+    <common-layout-center>
+      <div class="px-[16px]">
+        <div class="flex justify-between items-center py-[12px] text-[#FFF]" />
+        <!-- 时间选择器 -->
+        <summary-boss-select-time v-model="params" :time-where="timeWhere" @update-time="updateTimeFn" />
+        <summary-cashflow-card
+          card-title="收支数据"
+          :title="cashflowTitle"
+          :list="cashflowList"
+          :loading="cashflowLoading"
+          @getlist="getcashflowListFn" />
+      </div>
+    </common-layout-center>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+
+</style>

--- a/pages/summary/cashflow/index.vue
+++ b/pages/summary/cashflow/index.vue
@@ -4,6 +4,7 @@ useSeoMeta({
 })
 const { getPublicWhere, getCashflowList } = useCashflow()
 const { timeWhere } = storeToRefs(useCashflow())
+const { myStore } = storeToRefs(useStores())
 const params = ref({} as CashflowWhere)
 await getPublicWhere()
 
@@ -37,7 +38,7 @@ const cashflowTitle = ref<StockTitle[]>([])
 const cashflowList = ref<BossSalesList[]>([])
 cashflowLoading.value = true
 const getcashflowListFn = async () => {
-  const res = await getCashflowList({ ...params.value })
+  const res = await getCashflowList({ ...params.value, store_id: myStore.value.id })
   cashflowTitle.value = res?.title || []
   cashflowList.value = res?.list.sort((a, b) => {
     // 将合计项提到最前面
@@ -49,16 +50,17 @@ const getcashflowListFn = async () => {
   }) || []
   cashflowLoading.value = false
 }
-const getCashflowReq = async () => {
-  await getcashflowListFn()
-}
 
 const updateTimeFn = () => {
   listJump()
 }
+
+const changeStore = async () => {
+  await getcashflowListFn()
+}
 onMounted(async () => {
   await nextTick()
-  await getCashflowReq()
+  await getcashflowListFn()
 })
 </script>
 
@@ -67,6 +69,9 @@ onMounted(async () => {
     <common-layout-center>
       <div class="px-[16px]">
         <div class="flex justify-between items-center py-[12px] text-[#FFF]" />
+        <div class="w-fit color-[#fff] pb-[12px]">
+          <product-manage-company @change="changeStore" />
+        </div>
         <!-- 时间选择器 -->
         <summary-boss-select-time v-model="params" :time-where="timeWhere" @update-time="updateTimeFn" />
         <summary-cashflow-card

--- a/stores/cashflow.ts
+++ b/stores/cashflow.ts
@@ -1,0 +1,88 @@
+export const useCashflow = defineStore('cashflow', {
+  state: () => ({
+    // 收支数据
+    casflowWhere: {} as Where<CashflowWhere>,
+    casflowTitle: [] as any[],
+    casflowList: [] as BossSalesList[],
+    // 时间where
+    timeWhere: {} as Where<CashflowWhere>,
+    overview: {} as Record<string, string>,
+  }),
+  getters: {
+
+  },
+  actions: {
+    /**
+     * 将现金流Record对象转换为数组格式
+     * @param recordData Record格式的现金流数据
+     * @returns 转换后的数组格式数据
+     */
+    convertCashflowRecordToArray(recordData: CashflowList): BossSalesList[] {
+      return Object.entries(recordData).map(([paymentMethod, cashflowData]) => ({
+        name: paymentMethod,
+        ...cashflowData,
+      }))
+    },
+    /**
+     * 生成表格标题配置（公共函数）
+     * @param dataList 数据列表
+     * @returns 去重后的标题配置数组
+     */
+    generateTableTitle(dataList: any[]): StockTitle[] {
+      const resultSet = new Set<string>()
+      const result: StockTitle[] = []
+
+      if (dataList.length > 0) {
+        const firstItem = dataList[0]
+        Object.keys(firstItem).forEach((key) => {
+          const title = key === 'name' ? '支付方式' : key
+          if (!resultSet.has(title)) {
+            resultSet.add(title)
+            result.push({
+              title,
+              key,
+              width: '90px',
+              align: 'center',
+              fixed: key === 'name' ? 'left' : '',
+            })
+          }
+        })
+
+        // 对优先项进行排序：name优先级最高，total第二
+        result.sort((a, b) => {
+          if (a.key === 'name')
+            return -1
+          if (b.key === 'name')
+            return 1
+          return 0
+        })
+      }
+      return result
+    },
+
+    /**
+     * 获取公共where
+     */
+    async getPublicWhere() {
+      const { data } = await https.get<Where<CashflowWhere>>('/statistic/payment/where', undefined, true, false)
+      if (data.value?.code === HttpCode.SUCCESS) {
+        this.timeWhere = data.value?.data
+      }
+    },
+
+    async getCashflowList(params: CashflowWhere) {
+      const { data } = await https.post<{ list: CashflowList, overview: Record<string, string> }, CashflowWhere>('/statistic/payment/data', params, true, false)
+      if (data.value?.code === HttpCode.SUCCESS) {
+        this.casflowList = this.convertCashflowRecordToArray(data.value?.data?.list)
+        this.casflowTitle = this.generateTableTitle(this.casflowList)
+        this.overview = data.value?.data?.overview
+      }
+      return {
+        title: this.casflowTitle,
+        list: this.casflowList,
+      }
+    },
+
+  },
+
+})

--- a/stores/home.ts
+++ b/stores/home.ts
@@ -2,9 +2,11 @@ export const homeDataStore = defineStore('homeDataStore', {
   state: (): {
     todaySaleData?: todaySales // 今日本店销售数据
     TodayInventory?: TodayInventory // 今日库存数据
+    Payments?: Record<string, string> // 今日收支数据
   } => ({
     todaySaleData: undefined,
     TodayInventory: undefined,
+    Payments: undefined,
   }),
 
   getters: {
@@ -25,6 +27,14 @@ export const homeDataStore = defineStore('homeDataStore', {
       const { data } = await https.post<TodayInventory, { store_id: string }>('/statistic/today/product', req)
       if (data.value?.code === HttpCode.SUCCESS) {
         this.TodayInventory = data.value.data
+      }
+    },
+    // 今日收支
+    async myStoreTodayPayment(req: { store_id: string }) {
+      this.Payments = undefined
+      const { data } = await https.post<Record<string, string>, { store_id: string }>('/statistic/today/payment', req)
+      if (data.value?.code === HttpCode.SUCCESS) {
+        this.Payments = data.value.data
       }
     },
   },

--- a/types/cashflow.d.ts
+++ b/types/cashflow.d.ts
@@ -1,0 +1,17 @@
+interface CashflowWhere {
+  store_id?: string
+  duration?: number
+  endTime?: string
+  startTime?: string
+}
+
+/**
+ * 现金流项目数据接口
+ */
+type CashflowItem = Record<string, string>
+
+/**
+ * 现金流列表数据类型
+ * 使用 Record 类型映射支付方式到现金流数据
+ */
+type CashflowList = Record<string, CashflowItem>

--- a/types/stock.d.ts
+++ b/types/stock.d.ts
@@ -16,6 +16,6 @@ interface BossWhere {
 
 interface BossSalesList {
   name: string
-  total: string
+  total?: string
   [key]: string
 }


### PR DESCRIPTION
- 新增Payment.vue组件用于展示今日收支数据
- 在home store中添加Payments状态和获取方法
- 在首页集成收支卡片并添加点击标题跳转功能
- 修改Table和Card组件以支持标题点击事件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增“今日收支”卡片组件并在首页展示，首次加载与切换门店时请求并展示 Payments 数据。
  - 新增现金流汇总页与现金流卡片、对应 store/类型声明与数据获取接口；卡片支持按时段筛选并刷新列表。
  - 多处卡片（概览类/交叉店卡/现金流卡）新增可向外发出的标题点击事件（无负载）。

- **界面调整**
  - 卡片头部改为浅蓝背景并支持暗色叠加，点击区域显示手型指针。
  - 图表图例/系列过滤新增排除“支付方式”。
  - 顶栏 tabbar 增加堆叠层级样式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->