### PR TITLE
fix: 修改打印配件金额不正确

### DIFF
--- a/components/print/Board.vue
+++ b/components/print/Board.vue
@@ -84,7 +84,7 @@ const partTotalPrice = computed(() => {
   let totalPrice = 0
   props.details?.products?.forEach((item) => {
     if (item.type === 3) {
-      totalPrice += Number(item.accessorie.price) || 0
+      totalPrice += Number(item?.accessorie?.price) || 0
     }
   })
   return calc('(a)| =3 ~5,!n', {

--- a/components/print/Board.vue
+++ b/components/print/Board.vue
@@ -84,10 +84,7 @@ const partTotalPrice = computed(() => {
   let totalPrice = 0
   props.details?.products?.forEach((item) => {
     if (item.type === 3) {
-      totalPrice += calc('(a * b )| =3 ~5,!n', {
-        a: item?.accessorie.price,
-        b: item?.accessorie.quantity,
-      })
+      totalPrice += Number(item.accessorie.price) || 0
     }
   })
   return calc('(a)| =3 ~5,!n', {


### PR DESCRIPTION
修改打印配件金额不正确

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 修正打印面板中配件（类型为3）总价的计算逻辑：改为仅累计配件单价，取消按数量相乘，避免因数量误计导致总价偏差。
  - 保持最终总价的格式化显示不变，确保展示一致性与用户可读性。
  - 该变更为内部显示逻辑调整，不影响对外接口或导出行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->