### PR TITLE
feat: 调拨出库增加选择总部

### DIFF
--- a/pages/product/accessorie/allocate/add.vue
+++ b/pages/product/accessorie/allocate/add.vue
@@ -50,7 +50,6 @@ function changeStoer() {
 }
 
 await getAccessorieAllocateWhere()
-await getStoreList({ page: 1, limit: 20 })
 await getRegionList({ page: 1, limit: 20 })
 await changeStoer()
 async function submit() {

--- a/pages/product/accessorie/allocate/add.vue
+++ b/pages/product/accessorie/allocate/add.vue
@@ -128,6 +128,15 @@ const canShowFilter = (item: FilterWhere<AccessorieAllocate>) => {
 
   return true
 }
+
+const getStoreFun = useDebounceFn(async (query: string) => {
+  await getStoreList({ page: 1, limit: 20, where: { name: query } }, false, false)
+
+  storeCol.value = storesList.value.map((item: Stores) => ({
+    label: item.name,
+    value: item.id,
+  }))
+}, 500)
 </script>
 
 <template>
@@ -150,6 +159,9 @@ const canShowFilter = (item: FilterWhere<AccessorieAllocate>) => {
                               :placeholder="`选择${item.label}`"
                               :options="optonsToSelect(item.preset)"
                               clearable
+                              @focus="() => {
+                                storeCol = []
+                              }"
                             />
                           </template>
                           <template v-if="item.input === 'text'">
@@ -171,17 +183,13 @@ const canShowFilter = (item: FilterWhere<AccessorieAllocate>) => {
                               <n-select
                                 v-model:value="params[item.name as keyof AccessorieAllocateReq]"
                                 :placeholder="`选择${item.label}`"
-                                :options="storesList.map(v => ({
-                                  label: v.name,
-                                  value: v.id,
-                                }))"
+                                menu-size="large"
+                                :options="storeCol"
                                 clearable
-                                size="large"
+                                filterable
                                 remote
-                                @focus="(e) => {
-                                  focus(e)
-                                  getStoreList({ page: 1, limit: 20 })
-                                }"
+                                :on-search="getStoreFun"
+                                @focus="getStoreFun('')"
                               />
                             </template>
                             <template v-else-if="item.name === 'to_region_id'">
@@ -198,6 +206,16 @@ const canShowFilter = (item: FilterWhere<AccessorieAllocate>) => {
                                 @focus="(e) => {
                                   focus(e)
                                 }"
+                              />
+                            </template>
+                            <template v-else-if="item.name === 'to_headquarters_id'">
+                              <n-select
+                                v-model:value="params.to_headquarters_id"
+                                menu-size="large"
+                                placeholder="选择调入总部"
+                                :options="storeCol"
+                                clearable
+                                @focus="getStoreFun('总部')"
                               />
                             </template>
                           </template>

--- a/pages/product/accessorie/allocate/index.vue
+++ b/pages/product/accessorie/allocate/index.vue
@@ -4,8 +4,8 @@ import { NButton } from 'naive-ui'
 const { $toast } = useNuxtApp()
 const { getAccessorieAllocate, getAccessorieAllocateWhere, getAccessorieAllocateDetaills } = useAccessorieAllocate()
 const { accessorieAllocateList, accessorieAllocateFilterListToArray, accessorieAllocateFilterList, accessorieAllocateTotal } = storeToRefs(useAccessorieAllocate())
-const { storesList, myStore } = storeToRefs(useStores())
-const { getStoreList } = useStores()
+const { myStoreList, myStore } = storeToRefs(useStores())
+const { getMyStore } = useStores()
 const { searchPage, showtype } = storeToRefs(usePages())
 const { getRegionList } = useRegion()
 const { regionList } = storeToRefs(useRegion())
@@ -33,7 +33,7 @@ function changeRegion() {
 
 function changeStoer() {
   storeCol.value = []
-  storesList.value.forEach((item: Stores) => {
+  myStoreList.value.forEach((item: Stores) => {
     storeCol.value.push({ label: item.name, value: item.id })
   })
 }
@@ -144,7 +144,7 @@ function initStaffCol() {
 }
 
 try {
-  await getStoreList({ page: 1, limit: 20 })
+  await getMyStore()
   await getStaffList({ page: 1, limit: 30, where: { store_id: myStore.value.id } })
   await changeStoer()
   await getRegionList({ page: 1, limit: 20 })
@@ -408,7 +408,9 @@ async function focus() {
           placeholder="选择调入门店"
           :options="storeCol"
           clearable
-          @focus="focus"
+          @focus="() => {
+            getMyStore()
+          }"
         />
       </template>
       <template #to_region_id>

--- a/pages/product/accessorie/allocate/index.vue
+++ b/pages/product/accessorie/allocate/index.vue
@@ -4,15 +4,13 @@ import { NButton } from 'naive-ui'
 const { $toast } = useNuxtApp()
 const { getAccessorieAllocate, getAccessorieAllocateWhere, getAccessorieAllocateDetaills } = useAccessorieAllocate()
 const { accessorieAllocateList, accessorieAllocateFilterListToArray, accessorieAllocateFilterList, accessorieAllocateTotal } = storeToRefs(useAccessorieAllocate())
-const { myStoreList, myStore } = storeToRefs(useStores())
-const { getMyStore } = useStores()
+const { myStoreList, myStore, StoreStaffList } = storeToRefs(useStores())
+const { getMyStore, getStoreStaffList } = useStores()
 const { searchPage, showtype } = storeToRefs(usePages())
 const { getRegionList } = useRegion()
 const { regionList } = storeToRefs(useRegion())
 const { getAccessorieWhere } = useAccessorie()
 const { accessorieFilterListToArray } = storeToRefs(useAccessorie())
-const { getStaffList } = useStaff()
-const { staffList } = storeToRefs(useStaff())
 const route = useRoute()
 const searchKey = ref('')
 
@@ -138,14 +136,14 @@ const pageOption = ref({
 
 function initStaffCol() {
   staffCol.value = []
-  staffList.value.forEach((item: Staff) => {
+  StoreStaffList.value.forEach((item: StoresStaff) => {
     staffCol.value.push({ label: item.nickname, value: item.id })
   })
 }
 
 try {
   await getMyStore()
-  await getStaffList({ page: 1, limit: 30, where: { store_id: myStore.value.id } })
+  await getStoreStaffList({ id: myStore.value.id })
   await changeStoer()
   await getRegionList({ page: 1, limit: 20 })
   await changeRegion()
@@ -266,7 +264,7 @@ async function downloadDetails() {
 }
 
 async function focus() {
-  await getStaffList({ page: 1, limit: 30, where: { store_id: myStore.value.id } })
+  await getStoreStaffList({ id: myStore.value.id })
 }
 </script>
 
@@ -417,7 +415,6 @@ async function focus() {
         <n-select
           v-model:value="filterData.to_region_id"
           menu-size="large"
-          filterable
           placeholder="选择调入区域"
           :options="regionCol"
           clearable
@@ -428,7 +425,6 @@ async function focus() {
         <n-select
           v-model:value="filterData.initiator_id"
           menu-size="large"
-          filterable
           placeholder="选择发起人"
           :options="staffCol"
           clearable
@@ -439,7 +435,6 @@ async function focus() {
         <n-select
           v-model:value="filterData.receiver_id"
           menu-size="large"
-          filterable
           placeholder="选择接收人"
           :options="staffCol"
           clearable

--- a/pages/product/allocate/add.vue
+++ b/pages/product/allocate/add.vue
@@ -48,7 +48,7 @@ const getStoreFun = useDebounceFn(async (query: string) => {
     label: item.name,
     value: item.id,
   }))
-}, 300)
+}, 1000)
 
 await getAllocateWhere()
 await getStoreList({ page: 1, limit: 20 })

--- a/pages/product/allocate/add.vue
+++ b/pages/product/allocate/add.vue
@@ -37,13 +37,18 @@ useSeoMeta({
 
 /** 门店选择列表 */
 const storeCol = ref()
-
 function changeStoer() {
   storeCol.value = []
-  storesList.value.forEach((item: Stores) => {
-    storeCol.value.push({ label: item.name, value: item.id })
-  })
 }
+
+const getStoreFun = useDebounceFn(async (query: string) => {
+  await getStoreList({ page: 1, limit: 20, where: { name: query } }, false, false)
+
+  storeCol.value = storesList.value.map((item: Stores) => ({
+    label: item.name,
+    value: item.id,
+  }))
+}, 300)
 
 await getAllocateWhere()
 await getStoreList({ page: 1, limit: 20 })
@@ -177,7 +182,22 @@ function handleValidateButtonClick() {
                           placeholder="选择调入门店"
                           :options="storeCol"
                           clearable
-                          @focus="focus"
+                          filterable
+                          remote
+                          :on-search="getStoreFun"
+                          @focus="getStoreFun('')"
+                        />
+                      </n-form-item-gi>
+                    </template>
+                    <template v-if="params.method === 2">
+                      <n-form-item-gi :span="12" path="to_headquarters_id" label="调入总部" required>
+                        <n-select
+                          v-model:value="params.to_headquarters_id"
+                          menu-size="large"
+                          placeholder="选择调入总部"
+                          :options="storeCol"
+                          clearable
+                          @focus="getStoreFun('总部')"
                         />
                       </n-form-item-gi>
                     </template>

--- a/pages/product/allocate/add.vue
+++ b/pages/product/allocate/add.vue
@@ -51,7 +51,6 @@ const getStoreFun = useDebounceFn(async (query: string) => {
 }, 500)
 
 await getAllocateWhere()
-await getStoreList({ page: 1, limit: 20 })
 await changeStoer()
 
 /** 创建调拨单 */

--- a/pages/product/allocate/add.vue
+++ b/pages/product/allocate/add.vue
@@ -48,7 +48,7 @@ const getStoreFun = useDebounceFn(async (query: string) => {
     label: item.name,
     value: item.id,
   }))
-}, 1000)
+}, 500)
 
 await getAllocateWhere()
 await getStoreList({ page: 1, limit: 20 })
@@ -160,7 +160,9 @@ function handleValidateButtonClick() {
                         :placeholder="`选择${allocateFilterList.method?.label}`"
                         :options="presetToSelect('method')"
                         clearable
-                        @focus="focus"
+                        @focus="() => {
+                          storeCol = []
+                        }"
                       />
                     </n-form-item-gi>
                     <n-form-item-gi :span="12" path="type" required label="仓库类型">
@@ -171,7 +173,6 @@ function handleValidateButtonClick() {
                         :options="optonsToSelect(typePreset)"
                         clearable
                         :disabled="type"
-                        @focus="focus"
                       />
                     </n-form-item-gi>
                     <template v-if="params.method === 1">
@@ -208,11 +209,10 @@ function handleValidateButtonClick() {
                         placeholder="选择调拨原因"
                         :options="presetToSelect('reason') "
                         clearable
-                        @focus="focus"
                       />
                     </n-form-item-gi>
                     <n-form-item-gi :span="12" path="remark" label="备注">
-                      <n-input v-model:value="params.remark" type="textarea" round placeholder="输入备注" @focus="focus" />
+                      <n-input v-model:value="params.remark" type="textarea" round placeholder="输入备注" />
                     </n-form-item-gi>
                   </n-grid>
                 </n-form>

--- a/pages/product/allocate/index.vue
+++ b/pages/product/allocate/index.vue
@@ -552,7 +552,6 @@ async function downloadDetails() {
         <n-select
           v-model:value="filterData.from_store_id"
           menu-size="large"
-          filterable
           placeholder="选择调出门店"
           :options="storeCol"
           clearable
@@ -563,7 +562,6 @@ async function downloadDetails() {
         <n-select
           v-model:value="filterData.to_store_id"
           menu-size="large"
-          filterable
           placeholder="选择调入门店"
           :options="storeCol"
           clearable

--- a/pages/product/allocate/index.vue
+++ b/pages/product/allocate/index.vue
@@ -4,11 +4,9 @@ import { NButton } from 'naive-ui'
 const { $toast } = useNuxtApp()
 const { getAllocateList, getAllocateWhere, getAllocateDetails } = useAllocate()
 const { allocateList, allocateFilterListToArray, allocateFilterList, allocateTotal } = storeToRefs(useAllocate())
-const { myStoreList, myStore } = storeToRefs(useStores())
-const { getMyStore } = useStores()
+const { myStoreList, myStore, StoreStaffList } = storeToRefs(useStores())
+const { getMyStore, getStoreStaffList } = useStores()
 const { searchPage, showtype } = storeToRefs(usePages())
-const { getStaffList } = useStaff()
-const { staffList } = storeToRefs(useStaff())
 const { oldFilterListToArray } = storeToRefs(useOld())
 const { finishedFilterListToArray } = storeToRefs(useFinished())
 const { getFinishedWhere } = useFinished()
@@ -83,12 +81,12 @@ function changeStore() {
 
 function initStaffCol() {
   staffCol.value = []
-  staffList.value.forEach((item: Staff) => {
+  StoreStaffList.value.forEach((item: StoresStaff) => {
     staffCol.value.push({ label: item.nickname, value: item.id })
   })
 }
 await getMyStore()
-await getStaffList({ page: 1, limit: 30, where: { store_id: myStore.value.id } })
+await getStoreStaffList({ id: myStore.value.id })
 await changeStore()
 await initStaffCol()
 await getAllocateWhere()
@@ -572,7 +570,6 @@ async function downloadDetails() {
         <n-select
           v-model:value="filterData.initiator_id"
           menu-size="large"
-          filterable
           placeholder="选择发起人"
           :options="staffCol"
           clearable
@@ -583,7 +580,6 @@ async function downloadDetails() {
         <n-select
           v-model:value="filterData.receiver_id"
           menu-size="large"
-          filterable
           placeholder="选择接收人"
           :options="staffCol"
           clearable

--- a/stores/stores.ts
+++ b/stores/stores.ts
@@ -26,9 +26,9 @@ export const useStores = defineStore('Store', {
 
   actions: {
     // 门店列表
-    async getStoreList(req: ReqList<Stores>, search?: boolean) {
+    async getStoreList(req: ReqList<Stores>, search?: boolean, isLoading: boolean = true) {
       this.storesList = []
-      const { data } = await https.post<ResList<Stores>, ReqList<Stores>>('/store/list', req)
+      const { data } = await https.post<ResList<Stores>, ReqList<Stores>>('/store/list', req, true, isLoading)
       if (data.value?.code === HttpCode.SUCCESS) {
         this.total = data.value.data.total
         if (data.value.data.list.length > 0) {

--- a/types/accessorieAllocate.d.ts
+++ b/types/accessorieAllocate.d.ts
@@ -49,6 +49,7 @@ interface AccessorieAllocate {
   receiver: Staffs
   product_count: number
   product_total: number
+  to_headquarters_id: string
 }
 
 interface AccessorieAllocateInfo extends AccessorieAllocate {
@@ -114,6 +115,7 @@ interface AccessorieAllocateReq {
   enter_id?: Enter['id']
   /** 区域id */
   to_region_id: string
+  to_headquarters_id: string
 }
 interface AddAccessorieAllocateProduct {
   /**

--- a/types/allocate.d.ts
+++ b/types/allocate.d.ts
@@ -96,6 +96,8 @@ interface Allocate {
   /** 接收人 */
   receiver: Staff
   receiver_id: string
+  /** 总部  */
+  to_headquarters_id: string
 }
 
 interface AllocateReq {
@@ -135,6 +137,8 @@ interface AllocateReq {
    * 入库单id
    */
   enter_id?: Enter['id']
+  /** 总部 */
+  to_headquarters_id: string
 }
 
 interface AllocateInfoParams {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 调拨表单新增“总部”选择项，提交时一并保存。
  - 门店下拉支持远程搜索（防抖 500ms）、可筛选，聚焦时预加载/按需加载结果。
  - 员工下拉改为基于门店的店铺员工列表，打开时按需加载。

- 优化
  - 门店列表请求增加加载控制，减少不必要的全局加载提示。
  - 门店选项改为按用户交互异步填充，减少页面初始等待与干扰。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->