### PR TITLE
fix: 添加计件商品价格校验逻辑

### DIFF
--- a/components/sale/add/Product.vue
+++ b/components/sale/add/Product.vue
@@ -6,7 +6,7 @@ const Props = defineProps<{
   billingSet: BillingSet
   checkProductClass: (val: { class: number }) => any
 }>()
-
+const { $toast } = useNuxtApp()
 // 展示商品列表
 const orderObject = defineModel<Orders>({ default: {} as Orders })
 
@@ -126,6 +126,10 @@ const handleScoreReduceBlur = (scoreDeduct?: number) => {
 const addProduct = async (products: ProductFinisheds[]) => {
   orderObject.value.showProductList ??= []
   products.forEach(async (product: ProductFinisheds) => {
+    if (product.retail_type === 1 && Number(product.label_price) <= 0) {
+      $toast.error('计件商品标签价格不能小于等于0')
+      return
+    }
     const index = orderObject.value.showProductList?.findIndex(item => item.product_id === product?.id)
     //   添加成品到列表中
     if (index === -1) {

--- a/pages/sale/sales/add.vue
+++ b/pages/sale/sales/add.vue
@@ -162,6 +162,10 @@ const changeStore = async () => {
 // 添加商品
 const addProduct = async (product: DepositOrderInfoProducts) => {
   orderObject.value.showProductList ??= []
+  if (product.product_finished.retail_type === 1 && Number(product.product_finished.label_price) <= 0) {
+    $toast.error('计件商品标签价格不能小于等于0')
+    return
+  }
   const index = orderObject.value?.showProductList?.findIndex(item => item.id === product?.product_finished?.id)
   //   添加成品到列表中
   if (index === -1) {


### PR DESCRIPTION
在添加商品时检查计件商品(零售类型为1)的标签价格，如果小于等于0则显示错误提示并阻止添加。该修改同时在销售页和商品组件中实现，确保价格校验的一致性。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 添加无效价格提示：当添加计件商品且标签价格小于等于0时，显示“计件商品标签价格不能小于等于0”的提示。
- 修复
  - 阻止无效商品加入列表：对计件商品进行价格校验，发现非正数即终止添加，避免错误数据进入订单或清单。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->