### PR TITLE
feat: 为不同订单类型添加状态颜色映射并优化标签显示

### DIFF
--- a/components/common/tags/Index.vue
+++ b/components/common/tags/Index.vue
@@ -89,7 +89,7 @@ const finalStyle = computed(() => {
   }
   // 2️⃣ 没有 type，则根据 status/statusMap 取色
   if (props.status !== undefined && props.statusMap) {
-    return getStatusStyle(props.status, props.statusMap)
+    return getStatusStyle(props.status, props.statusMap) || { backgroundColor: 'rgb(221, 146, 0)', color: '#333' }
   }
   // 3️⃣ 默认值
   return { backgroundColor: 'rgb(221, 146, 0)', color: '#333' }

--- a/components/sale/Cards.vue
+++ b/components/sale/Cards.vue
@@ -4,6 +4,8 @@ const props = defineProps<{
   bg?: string
   title?: string | number
   tagText?: string | number
+  status?: number
+  statusMap?: { [key: number]: string }
 }>()
 </script>
 
@@ -21,7 +23,7 @@ const props = defineProps<{
         <slot name="status" />
       </div>
       <template v-if="props.tagText">
-        <common-tags :text="props.tagText" :type="props.bg" />
+        <common-tags :text="props.tagText" :status="props.status" :status-map="props.statusMap" :type="props.bg" />
       </template>
     </div>
     <!-- info -->

--- a/components/sale/deposit/List.vue
+++ b/components/sale/deposit/List.vue
@@ -38,7 +38,7 @@ const jumpSaleOreder = (id: string) => {
 <template>
   <div class="grid grid-cols-1 gap-[16px] " uno-lg="grid-cols-2" uno-md="grid-cols-2">
     <template v-for="(item, index) in props.info" :key="index">
-      <sale-cards :title="`订金单:${item.id}`" :tag-text="props.where.status?.preset[item.status!]">
+      <sale-cards :title="`订金单:${item.id}`" :status-map="DepositOrderStatusColor" :status="item.status" :tag-text="props.where.status?.preset[item.status!]">
         <template #info>
           <div class="info">
             <common-cell label="门店" :value="item.store?.name || '--'" />

--- a/components/sale/sales/List.vue
+++ b/components/sale/sales/List.vue
@@ -15,7 +15,7 @@ const handleClick = (id?: string) => {
 <template>
   <div class="grid grid-cols-1 gap-[16px] " uno-lg="grid-cols-2" uno-md="grid-cols-2">
     <template v-for="(item, index) in props.info" :key="index">
-      <sale-cards :title="`销售单号:${item.id}`" :tag-text="props.where.status?.preset[item.status]">
+      <sale-cards :title="`销售单号:${item.id}`" :status-map="OrderStatusColor" :tag-text="props.where.status?.preset[item.status]" :status="item.status">
         <template #info>
           <div class="info">
             <common-cell label="门店" :value="item.store.name || '--'" />

--- a/components/sale/service/list/Index.vue
+++ b/components/sale/service/list/Index.vue
@@ -20,7 +20,7 @@ const handleClick = (id?: string) => {
 <template>
   <div class="grid grid-cols-1 gap-[16px] " uno-lg="grid-cols-2" uno-md="grid-cols-2">
     <template v-for="(item, index) in props.list" :key="index">
-      <sale-cards :title="`单号:${item.id}`" :tag-text="props.where.status?.preset[item.status]">
+      <sale-cards :title="`单号:${item.id}`" :status="item.status" :status-map="ServiceOrderStatusColor" :tag-text="props.where.status?.preset[item.status]">
         <template #info>
           <div class="info">
             <common-cell label="门店" :value="item.store?.name" />

--- a/components/sale/statement/Sales.vue
+++ b/components/sale/statement/Sales.vue
@@ -13,28 +13,17 @@ const handleClick = (id?: string) => {
   }
   navigateTo(`/sale/sales/order?id=${id}`)
 }
-
-const returnColor = (number: number) => {
-  if (number === 1) {
-    return 'greyblue'
-  }
-  if (number === 2) {
-    return 'grey'
-  }
-  if (number === 3) {
-    return 'green'
-  }
-  if (number === 5) {
-    return 'red'
-  }
-  return 'orange'
-}
 </script>
 
 <template>
   <div class="grid grid-cols-1 gap-[16px] " uno-lg="grid-cols-2" uno-md="grid-cols-2">
     <template v-for="(item, index) in props.info" :key="index">
-      <sale-cards :title="`编号:${item.id}`" :tag-text="props.where.status?.preset[item.status]" :bg="returnColor(item.status)">
+      <sale-cards
+        :title="`编号:${item.id}`"
+        :tag-text="props.where.status?.preset[item.status]"
+        :status="item.status"
+        :status-map="OrderStatusColor"
+      >
         <template #info>
           <div class="info">
             <common-cell label="开单时间" :value="formatTimestampToDateTime(item.order.created_at) || '--'" />

--- a/composables/useOrderStatus.ts
+++ b/composables/useOrderStatus.ts
@@ -24,6 +24,14 @@ export enum OrderStatusText {
 
 }
 
+export const OrderStatusColor: Record<OrderStatusText, string> = {
+  [OrderStatusText.OrderSalesProductStatusWaitPay]: '#D97706',
+  [OrderStatusText.OrderSalesProductStatusCancel]: '#374151',
+  [OrderStatusText.OrderSalesProductStatusComplete]: '#059669',
+  [OrderStatusText.OrderSalesProductStatusRefund]: '#DC2626',
+  [OrderStatusText.OrderSalesProductStatusReturn]: '#DC2626',
+}
+
 // 订金单状态
 export enum DepositOrderStatus {
   /**
@@ -50,6 +58,14 @@ export enum DepositOrderStatus {
    * 已退货
    */
   Returned,
+}
+export const DepositOrderStatusColor: Record<DepositOrderStatus, string> = {
+  [DepositOrderStatus.PendingPayment]: '#D97706',
+  [DepositOrderStatus.Canceled]: '#374151',
+  [DepositOrderStatus.Booking]: '#4F46E5',
+  [DepositOrderStatus.Verified]: '#DC2626',
+  [DepositOrderStatus.HaveRefunded]: '#DC2626',
+  [DepositOrderStatus.Returned]: '#DC2626',
 }
 
 // 维修单订单状态
@@ -90,6 +106,17 @@ export enum serviceOrderStatus {
    * 已完成
    */
   Completed,
+}
+export const ServiceOrderStatusColor: Record<serviceOrderStatus, string> = {
+  [serviceOrderStatus.PendingPayment]: '#D97706',
+  [serviceOrderStatus.Cancelled]: '#374151',
+  [serviceOrderStatus.StoreReceived]: '#4F46E5',
+  [serviceOrderStatus.Refund]: '#DC2626',
+  [serviceOrderStatus.SentForRepair]: '#DC2626',
+  [serviceOrderStatus.UnderRepair]: '#4F46E5',
+  [serviceOrderStatus.RepairedAndReturned]: '#059669',
+  [serviceOrderStatus.ReadyForPickup]: '#D97706',
+  [serviceOrderStatus.Completed]: '#059669',
 }
 
 export enum ProductFinishedsStatus {


### PR DESCRIPTION
- 在 useOrderStatus.ts 中为销售单、订金单和维修单添加状态颜色映射
- 修改 common/tags 组件在没有匹配状态时显示默认颜色
- 更新多个组件传递状态和颜色映射给 sale-cards 组件