### PR TITLE
feat: 调拨单门店显示改为别名

### DIFF
--- a/components/product/allocate/AccessPrintInfo.vue
+++ b/components/product/allocate/AccessPrintInfo.vue
@@ -15,10 +15,10 @@ const { accessorieAllocateInfoTotal, accessorieAllocateFilterList } = storeToRef
         调拨单号: {{ accessorieAllocateInfoTotal.id }}
       </div>
       <div class="col-12" uno-sm="col-6" uno-md="col-4">
-        调出门店: {{ accessorieAllocateInfoTotal.from_store.name }}
+        调出门店: {{ accessorieAllocateInfoTotal.from_store.alias }}
       </div>
       <div class="col-12" uno-sm="col-6" uno-md="col-4">
-        调入门店: {{ accessorieAllocateInfoTotal.to_store.name }}
+        调入门店: {{ accessorieAllocateInfoTotal.to_store.alias }}
       </div>
       <div class="col-12" uno-sm="col-6" uno-md="col-4">
         调拨类型: {{ accessorieAllocateFilterList.method?.preset[accessorieAllocateInfoTotal.method] }}

--- a/components/product/allocate/Printinfo.vue
+++ b/components/product/allocate/Printinfo.vue
@@ -21,10 +21,10 @@ const { oldFilterList } = storeToRefs(useOld())
         调拨状态: {{ allocateFilterList.status?.preset[allocateInfoAll.status] }}
       </div>
       <div class="col-12" uno-sm="col-6" uno-md="col-4">
-        调出门店: {{ allocateInfoAll.from_store.name }}
+        调出门店: {{ allocateInfoAll.from_store.alias }}
       </div>
       <div class="col-12" uno-sm="col-6" uno-md="col-4">
-        调入门店: {{ allocateInfoAll.to_store.name }}
+        调入门店: {{ allocateInfoAll.to_store.alias }}
       </div>
       <div class="col-12" uno-sm="col-6" uno-md="col-4">
         调拨类型: {{ allocateFilterList.method?.preset[allocateInfoAll.method] }}

--- a/components/product/allocate/base.vue
+++ b/components/product/allocate/base.vue
@@ -53,10 +53,10 @@ const props = defineProps<{
                         </template>
                         <template v-else-if="item.input === 'search'">
                           <div v-if="item.name === 'to_store_id'" class="info-val">
-                            {{ props.info.to_store?.name }}
+                            {{ props.info.to_store?.alias }}
                           </div>
                           <div v-if="item.name === 'from_store_id'" class="info-val">
-                            {{ props.info.from_store?.name }}
+                            {{ props.info.from_store?.alias }}
                           </div>
                         </template>
                       </template>

--- a/pages/product/accessorie/allocate/index.vue
+++ b/pages/product/accessorie/allocate/index.vue
@@ -184,10 +184,10 @@ const cols = [
         render(row: any) {
           let value = row[item.name]
           if (item.name === 'to_store_id') {
-            value = row.to_store?.name
+            value = row.to_store?.alias
           }
           if (item.name === 'from_store_id') {
-            value = row.from_store?.name
+            value = row.from_store?.alias
           }
           if (item.name === 'to_region_id') {
             value = row.to_region?.name
@@ -341,12 +341,12 @@ async function focus() {
                           </template>
                           <template v-if="item.name === 'to_store_id'">
                             <div class="val">
-                              {{ info?.to_store?.name || '' }}
+                              {{ info?.to_store?.alias || '' }}
                             </div>
                           </template>
                           <template v-if="item.name === 'from_store_id'">
                             <div class="val">
-                              {{ info?.from_store?.name || '' }}
+                              {{ info?.from_store?.alias || '' }}
                             </div>
                           </template>
                           <template v-if="item.name === 'receiver_id'">

--- a/pages/product/accessorie/allocate/info.vue
+++ b/pages/product/accessorie/allocate/info.vue
@@ -214,12 +214,12 @@ const printFn = async () => {
                               </template>
                               <template v-if="item.name === 'to_store_id'">
                                 <div class="val">
-                                  {{ accessorieAllocateInfo?.to_store?.name || '' }}
+                                  {{ accessorieAllocateInfo?.to_store?.alias || '' }}
                                 </div>
                               </template>
                               <template v-if="item.name === 'from_store_id'">
                                 <div class="val">
-                                  {{ accessorieAllocateInfo?.from_store?.name || '' }}
+                                  {{ accessorieAllocateInfo?.from_store?.alias || '' }}
                                 </div>
                               </template>
                               <template v-if="item.name === 'receiver_id'">

--- a/pages/product/allocate/index.vue
+++ b/pages/product/allocate/index.vue
@@ -213,14 +213,14 @@ const cols = [
     title: '调出门店',
     key: 'from_store.name',
     render(row: Allocate) {
-      return row.from_store?.name ?? '-'
+      return row.from_store?.alias ?? '-'
     },
   },
   {
     title: '调入门店',
     key: 'to_store.name',
     render(row: Allocate) {
-      return row.to_store?.name ?? '-'
+      return row.to_store?.alias ?? '-'
     },
   },
   {
@@ -482,7 +482,7 @@ async function downloadDetails() {
                     调出门店
                   </div>
                   <div class="val">
-                    {{ info?.from_store?.name }}
+                    {{ info?.from_store?.alias }}
                   </div>
                 </div>
                 <div class="flex py-[4px] justify-between">
@@ -490,7 +490,7 @@ async function downloadDetails() {
                     调入门店
                   </div>
                   <div class="val">
-                    {{ info?.to_store?.name }}
+                    {{ info?.to_store?.alias }}
                   </div>
                 </div>
                 <div class="flex py-[4px] justify-between">

--- a/pages/product/allocate/info.vue
+++ b/pages/product/allocate/info.vue
@@ -226,16 +226,16 @@ async function downloadLocalFile() {
         ['入网费合计', res.data.product_total_access_fee],
         ['标签价合计', res.data.product_total_label_price],
         ['金重合计', res.data.product_total_weight_metal],
-        ['调出门店', res.data?.from_store?.name ?? ''],
-        ['调入门店', res.data?.to_store?.name ?? ''],
+        ['调出门店', res.data?.from_store?.alias ?? ''],
+        ['调入门店', res.data?.to_store?.alias ?? ''],
       ]
 
       if (type.value === GoodsTypePure.ProductFinish) {
-        await exportProductListToXlsx(res.data.product_finisheds, finishedFilterListToArray.value, '调拨单详情货品列表', summary)
+        await exportProductListToXlsx(res.data.product_finisheds, finishedFilterListToArray.value, '调拨单详情货品列表', summary, 1, undefined, true)
         loading.value = false
       }
       if (type.value === GoodsTypePure.ProductOld) {
-        await exportProductListToXlsx(res.data.product_olds, oldFilterListToArray.value, '调拨单详情货品列表', summary, GoodsTypePure.ProductOld)
+        await exportProductListToXlsx(res.data.product_olds, oldFilterListToArray.value, '调拨单详情货品列表', summary, GoodsTypePure.ProductOld, undefined, true)
         loading.value = false
       }
     }

--- a/utils/exportXlsx.ts
+++ b/utils/exportXlsx.ts
@@ -19,6 +19,7 @@ function extractPresets<T extends { name: string, preset?: Record<any, string> }
 function mapEnumValues(
   row: Record<string, any>,
   enumMap: Record<string, Record<any, string>>,
+  isAlias: boolean,
 ): Record<string, any> {
   const newRow: Record<string, any> = { ...row }
   for (const key in row) {
@@ -34,13 +35,18 @@ function mapEnumValues(
       newRow[key] = row[key] ? '是' : '否'
     }
     else if (key === 'store' || key === 'recycle_store' || key === 'operator') {
-      newRow[key] = row[key]?.name ?? ''
+      if (isAlias) {
+        newRow[key] = row[key]?.alias ?? ''
+      }
+      else {
+        newRow[key] = row[key]?.name ?? ''
+      }
     }
     else if (key === 'from_store_id') {
-      newRow[key] = row.from_store?.name ?? ''
+      newRow[key] = row.from_store?.alias ?? ''
     }
     else if (key === 'to_store_id') {
-      newRow[key] = row.to_store?.name ?? ''
+      newRow[key] = row.to_store?.alias ?? ''
     }
     else if (key === 'initiator_id') {
       newRow[key] = row.initiator?.nickname ?? ''
@@ -87,7 +93,8 @@ export function exportProductListToXlsx(
   name: string = '货品列表',
   summary?: [string, string | number][],
   type: 1 | 2 = 1,
-  header?: Record<string, string>,
+  header?: Record<string, string> | undefined,
+  isAlias: boolean = false, // 门店名是否导出别名
 ) {
   let headerMap
 
@@ -103,7 +110,7 @@ export function exportProductListToXlsx(
   )
 
   const enumMap = extractPresets(fields)
-  const mappedData = data.map(row => mapEnumValues(row, enumMap))
+  const mappedData = data.map(row => mapEnumValues(row, enumMap, isAlias))
   const aoaData = convertDataWithChineseHeaders(mappedData, fieldMap)
 
   let finalData: any[][] = []

--- a/utils/manyExportXlsx.ts
+++ b/utils/manyExportXlsx.ts
@@ -29,10 +29,10 @@ function mapEnumValues(
       newRow[key] = row[key]?.name ?? ''
     }
     else if (key === 'from_store_id') {
-      newRow[key] = row.from_store?.name ?? ''
+      newRow[key] = row.from_store?.alias ?? ''
     }
     else if (key === 'to_store_id') {
-      newRow[key] = row.to_store?.name ?? ''
+      newRow[key] = row.to_store?.alias ?? ''
     }
     else if (key === 'initiator_id') {
       newRow[key] = row.initiator?.nickname ?? ''


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - Excel 导出新增“使用门店别名”选项，支持在导出报表中以门店别名替代名称，维持未勾选时的原有行为。
  - 调拨相关界面统一显示门店别名：列表、详情、卡片视图、搜索结果与打印信息中的“调出门店/调入门店”均由名称改为别名，提升显示一致性与辨识度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->