### PR TITLE
feat: 添加合计行折线图并调整y轴配置

### DIFF
--- a/components/summary/Table.vue
+++ b/components/summary/Table.vue
@@ -28,23 +28,11 @@ const option = computed(() => {
       },
       triggerOn: 'click',
       confine: true,
-      formatter: (params: any) => {
-        let result = `${params[0].name}<br/>`
-        const total = params.reduce((acc: number, cur: any) => acc + cur.value, 0)
-        // 添加合计行
-        result += `<span style="color:#ff6b35;font-weight:bold">合计: ${total.toFixed(2)}</span><br/>`
-        // 遍历数据项，添加到结果中
-        params.forEach((item: any) => {
-          if (item.value) {
-            result += `${item.marker} ${item.seriesName}: ${item.value}<br/>`
-          }
-        })
-        return result
-      },
+
     },
     legend: {
       data: props.title
-        .filter((item: StockTitle) => item.title !== '门店' && item.title !== '合计' && item.title !== '支付方式')
+        .filter((item: StockTitle) => item.title !== '门店' && item.title !== '支付方式')
         .map((item: StockTitle) => item.title),
       left: 'center',
       top: 10,
@@ -70,11 +58,23 @@ const option = computed(() => {
         overflow: 'truncate',
       },
     },
-    yAxis: {
-      type: 'value',
-      axisTick: { show: false },
-      splitLine: { show: false },
-    },
+    yAxis: [
+      {
+        type: 'value',
+        axisTick: { show: false },
+        splitLine: { show: false },
+      },
+      {
+        type: 'value',
+        name: '',
+        position: 'right',
+        axisLine: {
+          lineStyle: {
+            color: '#505372',
+          },
+        },
+      },
+    ],
     dataZoom: [
       {
         type: 'inside',
@@ -89,9 +89,21 @@ const option = computed(() => {
         height: 20,
       },
     ],
-    series: props.title.filter((item: StockTitle) => item.title !== '门店' && item.title !== '合计')
-      .map((item: StockTitle, index) => {
-        return {
+    series: [
+      {
+        name: '合计',
+        type: 'line',
+        yAxisIndex: 0,
+        smooth: true,
+        data: props.list?.map((salesItem: BossSalesList) =>
+          Number(salesItem.total) || 0,
+        ),
+        itemStyle: {
+          color: '#505372',
+        },
+      },
+      ...props.title.filter((item: StockTitle) => item.title !== '门店' && item.title !== '合计')
+        .map((item: StockTitle, index) => ({
           name: item.title,
           type: 'bar',
           stack: 'total',
@@ -102,8 +114,9 @@ const option = computed(() => {
           itemStyle: {
             color: `hsl(${(index * 50) % 360}, 100%, 80%)`,
           },
-        }
-      }),
+        })),
+
+    ],
   }
 })
 </script>

--- a/pages/summary/boss/index.vue
+++ b/pages/summary/boss/index.vue
@@ -2,8 +2,8 @@
 useSeoMeta({
   title: 'Boss看板',
 })
-const { getPerformanceType, getPerformanceList, getPublicWhere, getOldSalesList, getOldSalesType, getFinishedSalesType, getFinishedSalesList, getStockList, getStockType, OldGetStockType, OldGetStockList, getRevenueList, getRevenueWhere } = useBoss()
-const { RevenueWhere, finishedSalesWhere, oldfilterWhere, oldSalesFilterWhere, finishedWhere } = storeToRefs(useBoss())
+const { getOldRecycleType, getOldRecycleList, getPerformanceType, getPerformanceList, getPublicWhere, getOldSalesList, getOldSalesType, getFinishedSalesType, getFinishedSalesList, getStockList, getStockType, OldGetStockType, OldGetStockList, getRevenueList, getRevenueWhere } = useBoss()
+const { oldRecycleFilterWhere, RevenueWhere, finishedSalesWhere, oldfilterWhere, oldSalesFilterWhere, finishedWhere } = storeToRefs(useBoss())
 const { timeWhere } = storeToRefs(useBoss())
 const params = ref({} as BossWhere)
 await getPublicWhere()
@@ -85,6 +85,25 @@ const getOldSaleReq = async () => {
   await getOldSaleListFn()
 }
 
+// 旧料回收
+const radioValueOldRecycle = ref<BossWhere['type']>(1)
+const oldRecycleTitle = ref<StockTitle[]>([])
+const oldRecycleList = ref<BossSalesList[]>([])
+const oldRecycleLoading = ref<boolean>(false)
+oldRecycleLoading.value = true
+const getOldRecycleListFn = async () => {
+  oldRecycleLoading.value = true
+  const res = await getOldRecycleList({ ...params.value, type: radioValueOldRecycle.value })
+  oldRecycleTitle.value = res?.title || []
+  oldRecycleList.value = res?.list || []
+  oldRecycleLoading.value = false
+}
+
+const getOldRecycleReq = async () => {
+  await getOldRecycleType()
+  await getOldRecycleListFn()
+}
+
 // 成品统计
 const radioValueFinsihed = ref<BossWhere['type']>(1)
 const finishedTitle = ref<StockTitle[]>([])
@@ -143,6 +162,7 @@ const updateTimeFn = () => {
 }
 onMounted(async () => {
   await nextTick()
+  await getOldRecycleReq()
   await getPerformanceReq()
   await getFinishedSaleReq()
   await getRevenueReq()
@@ -185,15 +205,25 @@ onMounted(async () => {
           :loading="finishedSalesLoading"
           @getlist="getFinishedSaleListFn" />
 
-        <!-- 旧料销售 -->
+        <!-- 旧料兑换 -->
         <summary-boss-card
           v-model="radioValueOldSale"
-          card-title="旧料回收"
+          card-title="旧料兑换"
           :where="oldSalesFilterWhere"
           :title="oldSalesTitle"
           :list="oldSalesList"
           :loading="oldSalesLoading"
           @getlist="getOldSaleListFn" />
+
+        <!-- 旧料回收 -->
+        <summary-boss-card
+          v-model="radioValueOldRecycle"
+          card-title="旧料回收"
+          :where="oldRecycleFilterWhere"
+          :title="oldRecycleTitle"
+          :list="oldRecycleList"
+          :loading="oldRecycleLoading"
+          @getlist="getOldRecycleListFn" />
         <!-- 成品统计 -->
         <summary-boss-card
           v-model="radioValueFinsihed"

--- a/pages/summary/sale/index.vue
+++ b/pages/summary/sale/index.vue
@@ -65,8 +65,13 @@ async function changeStores() {
         :loading="isLoading"
       />
       <summary-stock-chart
-        title="旧料大类"
-        :stock-category-date="salesData.old_class"
+        title="旧料兑换"
+        :stock-category-date="salesData.old_exchange"
+        :loading="isLoading"
+      />
+      <summary-stock-chart
+        title="旧料回收"
+        :stock-category-date="salesData.old_recycle"
         :loading="isLoading"
       />
       <summary-stock-chart

--- a/stores/boss.ts
+++ b/stores/boss.ts
@@ -20,6 +20,11 @@ export const useBoss = defineStore('boss', {
     oldSalesFilterWhere: {} as Where<BossWhere>,
     oldSalesTitle: [] as StockTitle[],
     oldSalesList: [] as BossSalesList[],
+    // 旧料回收
+    oldRecycleFilterWhere: {} as Where<BossWhere>,
+    oldRecycleTitle: [] as StockTitle[],
+    oldRecycleList: [] as BossSalesList[],
+
     // performance
     performanceWhere: {} as Where<BossWhere>,
     performanceTitle: [] as StockTitle[],
@@ -176,17 +181,17 @@ export const useBoss = defineStore('boss', {
      * 获取旧料销售类型
      */
     async getOldSalesType() {
-      const { data } = await https.get<Where<BossWhere>>('/statistic/boos/old_sales/where', undefined, true, false)
+      const { data } = await https.get<Where<BossWhere>>('/statistic/boos/old_exchange/where', undefined, true, false)
       if (data.value?.code === HttpCode.SUCCESS) {
         this.oldSalesFilterWhere = data.value?.data
       }
     },
 
     /**
-     * 获取旧料销售列表
+     * 获取旧料兑换列表
      */
     async getOldSalesList(params: BossWhere) {
-      const { data } = await https.post<any, BossWhere>('/statistic/boos/old_sales/data', params, true, false)
+      const { data } = await https.post<any, BossWhere>('/statistic/boos/old_exchange/data', params, true, false)
       if (data.value?.code === HttpCode.SUCCESS) {
         this.oldSalesList = data.value?.data
         // 使用公共函数生成标题配置
@@ -194,6 +199,29 @@ export const useBoss = defineStore('boss', {
       }
       return { list: this.oldSalesList, title: this.oldSalesTitle }
     },
+    /**
+     * 获取旧料回收类型
+     */
+    async getOldRecycleType() {
+      const { data } = await https.get<Where<BossWhere>>('/statistic/boos/old_recycle/where', undefined, true, false)
+      if (data.value?.code === HttpCode.SUCCESS) {
+        this.oldRecycleFilterWhere = data.value?.data
+      }
+    },
+
+    /**
+     * 获取旧料回收列表
+     */
+    async getOldRecycleList(params: BossWhere) {
+      const { data } = await https.post<any, BossWhere>('/statistic/boos/old_recycle/data', params, true, false)
+      if (data.value?.code === HttpCode.SUCCESS) {
+        this.oldRecycleList = data.value?.data
+        // 使用公共函数生成标题配置
+        this.oldRecycleTitle = this.generateTableTitle(this.oldRecycleList)
+      }
+      return { list: this.oldRecycleList, title: this.oldRecycleTitle }
+    },
+
     async getPerformanceType() {
       const { data } = await https.get<Where<BossWhere>>('/statistic/boos/performance/where', undefined, true, false)
       if (data.value?.code === HttpCode.SUCCESS) {

--- a/utils/objectSort.ts
+++ b/utils/objectSort.ts
@@ -1,29 +1,65 @@
+const priority = [
+  ['合计'],
+  ['成品', '旧料', '配件'],
+  ['收入', '支出'],
+  ['销售', '退款'],
+  ['兑换', '回收'],
+  ['金额', '销售额', '件数'],
+]
+
+/**
+ * 查找名称中包含层级中哪个关键词，并返回其索引
+ * @param name 要检查的名称
+ * @param level 优先级的一个层级
+ * @returns 匹配到的关键词索引，未匹配到则返回-1
+ */
+function findMatchingIndex(name: string, level: string[]): number {
+  for (let i = 0; i < level.length; i++) {
+    if (name.includes(level[i])) {
+      return i
+    }
+  }
+  return -1
+}
+
+/**
+ * 根据优先级列表对对象的键进行排序
+ * @param obj 要排序的对象
+ * @returns 排序后的新对象
+ */
 export function reorderObject(obj: Record<string, any>): Record<string, any> {
-  if (Object.keys(obj).length === 0)
-    return obj
+  // 获取对象的键值对并排序
+  const sortedEntries = Object.entries(obj).sort(([keyA], [keyB]) => {
+    // 遍历所有优先级层级进行比较
+    for (const level of priority) {
+      const indexA = findMatchingIndex(keyA, level)
+      const indexB = findMatchingIndex(keyB, level)
 
-  const priority = ['合计', '收入', '支出', '销售', '回收', '成品', '旧料', '配件']
-
-  const entries = Object.entries(obj)
-
-  const sorted = entries
-    .map(([key, value]) => {
-      // 如果还是对象，递归处理
-      if (value && typeof value === 'object' && !Array.isArray(value)) {
-        return [key, reorderObject(value)]
+      // 情况1：两个键都在当前层级找到匹配
+      if (indexA !== -1 && indexB !== -1) {
+        // 如果索引不同，直接返回比较结果
+        if (indexA !== indexB) {
+          return indexA - indexB
+        }
+        // 如果索引相同，继续检查下一层级
+        continue
       }
-      return [key, value]
-    })
-    .sort(([keyA], [keyB]) => {
-      const idxA = typeof keyA === 'string'
-        ? priority.findIndex(p => keyA.includes(p))
-        : -1
-      const idxB = typeof keyB === 'string'
-        ? priority.findIndex(p => keyB.includes(p))
-        : -1
 
-      return (idxA === -1 ? Infinity : idxA) - (idxB === -1 ? Infinity : idxB)
-    })
+      // 情况2：只有一个键在当前层级找到匹配，有匹配的排在前面
+      if (indexA !== -1) {
+        return -1
+      }
+      if (indexB !== -1) {
+        return 1
+      }
 
-  return Object.fromEntries(sorted)
+      // 情况3：两个键都不在当前层级，继续检查下一层级
+    }
+
+    // 所有层级都没有匹配，按默认字符串顺序排序
+    return keyA.localeCompare(keyB)
+  })
+
+  // 将排序后的键值对转换回对象
+  return Object.fromEntries(sortedEntries)
 }


### PR DESCRIPTION
在图表中新增合计行的折线图显示，并添加右侧y轴配置。移除原有的tooltip格式化函数，改为直接在series中处理合计数据。调整图例过滤条件，不再排除'合计'项。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 新功能
  * 新增“旧料回收”模块与对应展示卡片与图表，单独加载与切换类型。
  * 图表新增“合计”折线，直观展示总额走势；柱状系列按分类堆叠并应用动态配色。
* 重构
  * 支持双 y 轴显示，右侧轴带颜色标识，便于对比阅读；系列顺序调整为先总额折线后动态柱状。
  * 图例优化，仅默认排除“门店”“支付方式”，其余可筛选；提示改为默认格式以提升一致性。
* 其他
  * 列表排序逻辑升级为多层优先级规则，排序更灵活。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->