### PR TITLE
fix: 修改销售单打印

### DIFF
--- a/components/print/Board.vue
+++ b/components/print/Board.vue
@@ -18,6 +18,10 @@ const props = defineProps<{
    * 支付方式
    */
   payMethod?: string
+  /**
+   * 打印单类型
+   */
+  finishedWhere?: Where<ProductFinisheds>
 }>()
 
 const intercepting = () => {
@@ -155,23 +159,26 @@ const partTotalPrice = computed(() => {
                   <th class="table-header" style="width: 16%;">
                     条码
                   </th>
-                  <th class="table-header" style="width: 12%;">
+                  <th class="table-header" style="width: 16%;">
                     名称
                   </th>
-                  <th class="table-header" style="width: 12%;">
+                  <th class="table-header" style="width: 8%;">
+                    工艺
+                  </th>
+                  <th class="table-header" style="width: 6%;">
                     金重
                   </th>
-                  <th class="table-header" style="width: 12%;">
+                  <th class="table-header" style="width: 6%;">
                     金价
                   </th>
-                  <th class="table-header" style="width: auto;">
+                  <th class="table-header" style="width: 6%;">
                     工费
                   </th>
-                  <th class="table-header" style="width: 12%;">
+                  <th class="table-header" style="width: auto;">
                     证书号
                   </th>
-                  <th class="table-header" style="width: 12%;">
-                    单价
+                  <th class="table-header" style="width: 10%;">
+                    标签价
                   </th>
                   <th class="table-header" style="width: 16%;">
                     应付金额
@@ -187,6 +194,9 @@ const partTotalPrice = computed(() => {
                       </td>
                       <td class="table-body">
                         {{ item.finished.product?.name || '' }}
+                      </td>
+                      <td class="table-body">
+                        {{ finishedWhere?.craft?.preset[item.finished.product?.craft as number] || '' }}
                       </td>
                       <td class="table-body">
                         <template v-if="item.finished.product?.retail_type !== 1">
@@ -229,16 +239,19 @@ const partTotalPrice = computed(() => {
                   <th class="table-header" style=" width:16%;">
                     旧料名称
                   </th>
-                  <th class="table-header" style=" width:12%;">
+                  <th class="table-header" style="width: 8%;">
+                    工艺
+                  </th>
+                  <th class="table-header" style=" width:8%;">
                     金重
                   </th>
-                  <th class="table-header" style=" width:12%;">
+                  <th class="table-header" style=" width:10%;">
                     回收金价
                   </th>
-                  <th class="table-header" style=" width:auto;">
+                  <th class="table-header" style=" width:8%;">
                     工费
                   </th>
-                  <th class="table-header" style=" width:12%;">
+                  <th class="table-header" style=" width:auto;">
                     原单价
                   </th>
                   <th class="table-header" style=" width:16%;">
@@ -255,6 +268,9 @@ const partTotalPrice = computed(() => {
                       </td>
                       <td class="table-body">
                         {{ item.old.product?.name || '' }}
+                      </td>
+                      <td class="table-body">
+                        {{ finishedWhere?.craft?.preset[item.old.product?.craft as number] || '' }}
                       </td>
                       <td class="table-body">
                         {{ item.old.product?.weight_metal || '' }}
@@ -316,16 +332,16 @@ const partTotalPrice = computed(() => {
                   <th class="table-header" style="width: 16%;">
                     名称
                   </th>
-                  <th class="table-header" style="width: 12%;">
+                  <th class="table-header" style="width: 8%;">
                     金重
                   </th>
-                  <th class="table-header" style="width: 16%;">
+                  <th class="table-header" style="width: 8%;">
                     金价/单价
                   </th>
-                  <th class="table-header" style="width: auto;">
+                  <th class="table-header" style="width: 8%;">
                     工费
                   </th>
-                  <th class="table-header" style="width: 16%;">
+                  <th class="table-header" style="width: auto;">
                     证书号
                   </th>
                   <th class="table-header" style="width: 16%;">
@@ -375,10 +391,10 @@ const partTotalPrice = computed(() => {
                   <th class="table-header" style=" width:16%;">
                     旧料名称
                   </th>
-                  <th class="table-header" style=" width:12%;">
+                  <th class="table-header" style=" width:8%;">
                     金重
                   </th>
-                  <th class="table-header" style=" width:16%;">
+                  <th class="table-header" style=" width:8%;">
                     回收金价/原单价
                   </th>
                   <th class="table-header" style=" width:auto;">

--- a/components/sale/order/Detail.vue
+++ b/components/sale/order/Detail.vue
@@ -139,6 +139,13 @@ const onReturnProduct = async (index: number) => {
                 <common-cell label="商品条码" :value="obj.finished.product?.code" />
                 <common-cell label="商品名称" :value="obj.finished.product?.name" val-color="#4C8DF6" />
                 <common-cell label="零售方式" :value="props.productFilter.retail_type?.preset[(obj.finished.product?.retail_type as number)]" />
+                <common-cell label="材质" :value="props.productFilter.material?.preset[(obj.finished.product?.material as number)]" />
+                <common-cell label="成色" :value="props.productFilter.quality?.preset[(obj.finished.product?.quality as number)]" />
+                <common-cell label="主石" :value="props.productFilter.gem?.preset[(obj.finished.product?.gem as number)]" />
+                <common-cell label="主石重(ct)" :value="obj.finished.product?.weight_gem" />
+                <common-cell label="品类" :value="props.productFilter.category?.preset[obj.finished.product?.category!] " />
+                <common-cell label="品牌" :value="props.productFilter.brand?.preset[obj.finished.product?.brand!] " />
+                <common-cell label="工艺" :value="props.productFilter.craft?.preset[(obj.finished.product?.craft as number)]" />
                 <common-cell label="金重(g)" :value="obj.finished.product?.weight_metal" />
                 <common-cell label="金价(元/g)" format="￥" :value="obj.finished.price_gold" />
                 <common-cell label="工费" format="￥" :value="obj.finished.labor_fee" />

--- a/pages/sale/sales/order.vue
+++ b/pages/sale/sales/order.vue
@@ -98,7 +98,7 @@ const printPre = () => {
 
   const PrintComponent = defineComponent({
     render() {
-      return h(PrintTemp, { details: printDetail.value, type: 1, payMethod: gather.value, numerical: tempInfo.value })
+      return h(PrintTemp, { details: printDetail.value, type: 1, payMethod: gather.value, numerical: tempInfo.value, finishedWhere: finishedFilterList.value })
     },
   })
   getMethod()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新功能
  * 打印模板新增“工艺”列，展示成品与旧料的工艺信息。
  * 订单详情（成品信息）新增字段：材质、成色、主石、主石重(ct)、品类、品牌、工艺，完善商品信息展示。
  * 页面向打印模板传递成品筛选配置，支持映射并显示对应工艺。
* 样式
  * 调整打印表格列宽，适配新增“工艺”“标签价”等列，优化排版与对齐。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->